### PR TITLE
Scrum 103 main menu api schemas

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
-from routes import users, activities, activity_types, auth
+from routes import users, activities, activity_types, auth, main_menu
 from dependencies.database import engine, Base
 
 app = FastAPI()
@@ -26,6 +26,9 @@ app.include_router(users.router, prefix="/users", tags=["Users"])
 app.include_router(activities.router, prefix="/activities", tags=["Activities"])
 app.include_router(activity_types.router, prefix="/activity_types", tags=["Activity Types"])
 app.include_router(auth.router, tags=["Auth"])
+
+# Include UI routers
+app.include_router(main_menu.router, prefix="/ui/menu", tags=["Main Menu"])
 
 # Run with: uvicorn main:app --reload --log-config logging_config.json
 # load env file: --env-file <env_file>

--- a/routes/main_menu.py
+++ b/routes/main_menu.py
@@ -1,14 +1,15 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from typing import List
 from pymongo import MongoClient
 from schemas.ui.main_menu import MainMenu, MenuOption
 from dependencies.mongodb import db
+from dependencies.auth import check_role
 
 router = APIRouter()
 
 main_menu_collection = db['main_menu_collection']
 
-@router.post("/", response_model=MainMenu)
+@router.post("/", response_model=MainMenu, dependencies=[Depends(check_role(["customization"]))])
 def create_main_menu(main_menu: MainMenu):
     if main_menu_collection.count_documents({}) > 0:
         raise HTTPException(status_code=400, detail="Main menu already exists")
@@ -25,7 +26,7 @@ def get_main_menu():
         raise HTTPException(status_code=404, detail="Main menu not found")
     return main_menu
 
-@router.put("/", response_model=MainMenu)
+@router.put("/", response_model=MainMenu, dependencies=[Depends(check_role(["customization"]))])
 def update_main_menu(main_menu: MainMenu):
     main_menu_dict = main_menu.dict()
     result = main_menu_collection.update_one({}, {"$set": main_menu_dict})
@@ -33,14 +34,14 @@ def update_main_menu(main_menu: MainMenu):
         raise HTTPException(status_code=404, detail="Main menu not found")
     return main_menu
 
-@router.delete("/", response_model=MainMenu)
+@router.delete("/", response_model=MainMenu, dependencies=[Depends(check_role(["customization"]))])
 def delete_main_menu():
     main_menu = main_menu_collection.find_one_and_delete({})
     if not main_menu:
         raise HTTPException(status_code=404, detail="Main menu not found")
     return main_menu
 
-@router.post("/option", response_model=MainMenu)
+@router.post("/option", response_model=MainMenu, dependencies=[Depends(check_role(["customization"]))])
 def add_menu_option(option: MenuOption):
     main_menu = main_menu_collection.find_one()
     if not main_menu:
@@ -51,7 +52,7 @@ def add_menu_option(option: MenuOption):
         raise HTTPException(status_code=500, detail="Failed to add menu option")
     return main_menu
 
-@router.put("/option/{option_index}", response_model=MainMenu)
+@router.put("/option/{option_index}", response_model=MainMenu, dependencies=[Depends(check_role(["customization"]))])
 def update_menu_option(option_index: int, option: MenuOption):
     main_menu = main_menu_collection.find_one()
     if not main_menu:
@@ -64,7 +65,7 @@ def update_menu_option(option_index: int, option: MenuOption):
         raise HTTPException(status_code=500, detail="Failed to update menu option")
     return main_menu
 
-@router.delete("/option/{option_index}", response_model=MainMenu)
+@router.delete("/option/{option_index}", response_model=MainMenu, dependencies=[Depends(check_role(["customization"]))])
 def delete_menu_option(option_index: int):
     main_menu = main_menu_collection.find_one()
     if not main_menu:

--- a/routes/main_menu.py
+++ b/routes/main_menu.py
@@ -1,0 +1,78 @@
+from fastapi import APIRouter, HTTPException
+from typing import List
+from pymongo import MongoClient
+from schemas.ui.main_menu import MainMenu, MenuOption
+from dependencies.mongodb import db
+
+router = APIRouter()
+
+main_menu_collection = db['main_menu_collection']
+
+@router.post("/", response_model=MainMenu)
+def create_main_menu(main_menu: MainMenu):
+    if main_menu_collection.count_documents({}) > 0:
+        raise HTTPException(status_code=400, detail="Main menu already exists")
+    main_menu_dict = main_menu.dict()
+    result = main_menu_collection.insert_one(main_menu_dict)
+    if not result.acknowledged:
+        raise HTTPException(status_code=500, detail="Failed to create main menu")
+    return main_menu
+
+@router.get("/", response_model=MainMenu)
+def get_main_menu():
+    main_menu = main_menu_collection.find_one()
+    if not main_menu:
+        raise HTTPException(status_code=404, detail="Main menu not found")
+    return main_menu
+
+@router.put("/", response_model=MainMenu)
+def update_main_menu(main_menu: MainMenu):
+    main_menu_dict = main_menu.dict()
+    result = main_menu_collection.update_one({}, {"$set": main_menu_dict})
+    if result.matched_count == 0:
+        raise HTTPException(status_code=404, detail="Main menu not found")
+    return main_menu
+
+@router.delete("/", response_model=MainMenu)
+def delete_main_menu():
+    main_menu = main_menu_collection.find_one_and_delete({})
+    if not main_menu:
+        raise HTTPException(status_code=404, detail="Main menu not found")
+    return main_menu
+
+@router.post("/option", response_model=MainMenu)
+def add_menu_option(option: MenuOption):
+    main_menu = main_menu_collection.find_one()
+    if not main_menu:
+        raise HTTPException(status_code=404, detail="Main menu not found")
+    main_menu['options'].append(option.dict())
+    result = main_menu_collection.update_one({}, {"$set": main_menu})
+    if result.matched_count == 0:
+        raise HTTPException(status_code=500, detail="Failed to add menu option")
+    return main_menu
+
+@router.put("/option/{option_index}", response_model=MainMenu)
+def update_menu_option(option_index: int, option: MenuOption):
+    main_menu = main_menu_collection.find_one()
+    if not main_menu:
+        raise HTTPException(status_code=404, detail="Main menu not found")
+    if option_index >= len(main_menu['options']):
+        raise HTTPException(status_code=404, detail="Menu option not found")
+    main_menu['options'][option_index] = option.dict()
+    result = main_menu_collection.update_one({}, {"$set": main_menu})
+    if result.matched_count == 0:
+        raise HTTPException(status_code=500, detail="Failed to update menu option")
+    return main_menu
+
+@router.delete("/option/{option_index}", response_model=MainMenu)
+def delete_menu_option(option_index: int):
+    main_menu = main_menu_collection.find_one()
+    if not main_menu:
+        raise HTTPException(status_code=404, detail="Main menu not found")
+    if option_index >= len(main_menu['options']):
+        raise HTTPException(status_code=404, detail="Menu option not found")
+    main_menu['options'].pop(option_index)
+    result = main_menu_collection.update_one({}, {"$set": main_menu})
+    if result.matched_count == 0:
+        raise HTTPException(status_code=500, detail="Failed to delete menu option")
+    return main_menu

--- a/schemas/ui/main_menu.py
+++ b/schemas/ui/main_menu.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+from typing import List
+from .menu import MenuOption
+
+class MainMenu(BaseModel):
+    options: List[MenuOption]
+    


### PR DESCRIPTION
This pull request introduces a new feature to the application by adding a main menu UI component. The most important changes include importing the new `main_menu` router, defining the main menu endpoints, and creating the necessary schemas for the main menu.

### Main Menu Feature Addition:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L7-R7): Imported the `main_menu` router and included it in the FastAPI application with the prefix `/ui/menu` and the tag `Main Menu`. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L7-R7) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R30-R32)

* [`routes/main_menu.py`](diffhunk://#diff-625c3991590f64b9ce7c85315ce4d15925c023de2e9f592e8be2080a7c356890R1-R79): Defined the main menu endpoints, including creating, retrieving, updating, and deleting the main menu and its options. These endpoints are protected by role-based access control.

### Schema Definitions:

* [`schemas/ui/main_menu.py`](diffhunk://#diff-7df40ec9d93cee89499903bafe89a0c89acd104593a5668a9f0c8307ae7506acR1-R7): Added the `MainMenu` schema, which includes a list of `MenuOption` objects.