### PR TITLE
fixed

### DIFF
--- a/dependencies/app.py
+++ b/dependencies/app.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+
+_app: FastAPI = None
+
+def set_current_app(app: FastAPI):
+    global _app
+    _app = app
+
+def get_current_app() -> FastAPI:
+    return _app


### PR DESCRIPTION
This pull request introduces a new mechanism for managing the current FastAPI application instance in `dependencies/app.py`. The most important changes include the addition of a global variable to store the app instance and two functions to set and retrieve this instance.

Global app instance management:

* [`dependencies/app.py`](diffhunk://#diff-19ba9da59aedef811f0343c398c73ec52f8041c2f4d41df806f585f49307180cR1-R10): Added a global `_app` variable to store the FastAPI application instance.
* [`dependencies/app.py`](diffhunk://#diff-19ba9da59aedef811f0343c398c73ec52f8041c2f4d41df806f585f49307180cR1-R10): Implemented `set_current_app` function to set the global FastAPI application instance.
* [`dependencies/app.py`](diffhunk://#diff-19ba9da59aedef811f0343c398c73ec52f8041c2f4d41df806f585f49307180cR1-R10): Implemented `get_current_app` function to retrieve the global FastAPI application instance.