### PR TITLE
Fix table creation in plugins & add response_model to api router

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,8 +46,6 @@ class CoffeeBreakLoggerMiddleware(BaseHTTPMiddleware):
 
 app.add_middleware(CoffeeBreakLoggerMiddleware)
 
-Base.metadata.create_all(bind=engine)
-
 # Create default main menu if it does not exist
 async def create_default_main_menu():
     main_menu_collection = db['main_menu_collection']
@@ -88,6 +86,8 @@ async def create_default_color_theme():
 
 set_current_app(routes_app)
 plugin_loader('plugins', routes_app)
+
+Base.metadata.create_all(bind=engine) # should only be called after all plugins being loaded
 
 # Include all routers from routes/__init__.py
 app.include_router(routes_app, prefix="/api/v1")

--- a/utils/api.py
+++ b/utils/api.py
@@ -11,44 +11,48 @@ class Router:
         self.routes: List[Dict] = []
         self.events: Dict[str, Callable] = {}
 
-    def add_route(self, path: str, method: str, handler: Callable):
+    def add_route(self, path: str, method: str, handler: Callable, response_model=None):
         """Registers a new route definition."""
-
-        self.routes.append({"path": path, "method": method.upper(), "handler": handler})
+        self.routes.append({
+            "path": path,
+            "method": method.upper(),
+            "handler": handler,
+            "response_model": response_model
+        })
         logger.info(f"Registered route: {method.upper()} {path}")
 
-    def get(self, path: str):
+    def get(self, path: str, response_model=None):
         """Decorator for defining a GET route."""
         def wrapper(handler: Callable):
-            self.add_route(path, "GET", handler)
+            self.add_route(path, "GET", handler, response_model)
             return handler
         return wrapper
 
-    def post(self, path: str):
+    def post(self, path: str, response_model=None):
         """Decorator for defining a POST route."""
         def wrapper(handler: Callable):
-            self.add_route(path, "POST", handler)
+            self.add_route(path, "POST", handler, response_model)
             return handler
         return wrapper
 
-    def put(self, path: str):
+    def put(self, path: str, response_model=None):
         """Decorator for defining a PUT route."""
         def wrapper(handler: Callable):
-            self.add_route(path, "PUT", handler)
+            self.add_route(path, "PUT", handler, response_model)
             return handler
         return wrapper
 
-    def delete(self, path: str):
+    def delete(self, path: str, response_model=None):
         """Decorator for defining a DELETE route."""
         def wrapper(handler: Callable):
-            self.add_route(path, "DELETE", handler)
+            self.add_route(path, "DELETE", handler, response_model)
             return handler
         return wrapper
 
-    def patch(self, path: str):
+    def patch(self, path: str, response_model=None):
         """Decorator for defining a PATCH route."""
         def wrapper(handler: Callable):
-            self.add_route(path, "PATCH", handler)
+            self.add_route(path, "PATCH", handler, response_model)
             return handler
         return wrapper
 
@@ -103,15 +107,15 @@ class Router:
             router = APIRouter()
             for route in self.routes:
                 if route["method"] == "GET":
-                    router.get(route["path"])(route["handler"])
+                    router.get(route["path"], response_model=route["response_model"])(route["handler"])
                 elif route["method"] == "POST":
-                    router.post(route["path"])(route["handler"])
+                    router.post(route["path"], response_model=route["response_model"])(route["handler"])
                 elif route["method"] == "PUT":
-                    router.put(route["path"])(route["handler"])
+                    router.put(route["path"], response_model=route["response_model"])(route["handler"])
                 elif route["method"] == "DELETE":
-                    router.delete(route["path"])(route["handler"])
+                    router.delete(route["path"], response_model=route["response_model"])(route["handler"])
                 elif route["method"] == "PATCH":
-                    router.patch(route["path"])(route["handler"])
+                    router.patch(route["path"], response_model=route["response_model"])(route["handler"])
                 elif route["method"] == "OPTIONS":
                     router.options(route["path"])(route["handler"])
                 elif route["method"] == "HEAD":


### PR DESCRIPTION
This PR intends to fix the tables in plugins that are not being created. The problem was caused because the table creation occurs before their declarations.



### Details:
This pull request includes changes to improve the initialization process and enhance the API route definition capabilities. The most important changes include moving the database metadata creation to occur after all plugins are loaded, and adding support for specifying a response model in API route definitions.

Initialization improvements:

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L49-L50): Moved `Base.metadata.create_all(bind=engine)` to occur after all plugins are loaded to ensure proper initialization order. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L49-L50) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R90-R91)

API route enhancements:

* [`utils/api.py`](diffhunk://#diff-9bf5b5974ccbd7b7f129937cd52f28df433bb5a1f03d8e6056e52fef617d51c1L14-R55): Modified the `add_route` method and related decorators (`get`, `post`, `put`, `delete`, `patch`) to support an optional `response_model` parameter, allowing for more detailed route definitions.
* [`utils/api.py`](diffhunk://#diff-9bf5b5974ccbd7b7f129937cd52f28df433bb5a1f03d8e6056e52fef617d51c1L106-R118): Updated the `get_router` method to include the `response_model` parameter when registering routes with the `APIRouter`.