### PR TITLE
create page service and refactor

### DIFF
--- a/routes/ui/page.py
+++ b/routes/ui/page.py
@@ -1,8 +1,8 @@
 from fastapi import Depends, APIRouter, HTTPException
-from models.ui.page import page_model
 import schemas.ui.page as page_schema
 from dependencies.auth import check_role
 from bson import ObjectId
+from services.ui.page_service import page_service
 
 router = APIRouter()
 
@@ -11,15 +11,13 @@ async def create_page(page: page_schema.PageSchema, user_info: dict = Depends(ch
     components_with_id = [
         {**c.dict(), "component_id": str(ObjectId())} for c in page.components
     ]
-    page_id = await page_model.create_page(page.title, components_with_id)
-    
+    page_id = await page_service.create_page(page.title, components_with_id)
     return {"page_id": page_id, "title": page.title, "components": components_with_id}
-
 
 
 @router.put("/{page_id}", response_model=page_schema.PageResponse, summary="Update an existing page")
 async def update_page(page_id: str, page: page_schema.PageSchema, user_info: dict = Depends(check_role(["customization"]))):
-    updated = await page_model.update_page(page_id, page.title, [c.dict() for c in page.components])
+    updated = await page_service.update_page(page_id, page.title, [c.dict() for c in page.components])
     if not updated:
         raise HTTPException(status_code=404, detail="Error updating page")
     return {"page_id": page_id, "title": page.title, "components": page.components}
@@ -27,7 +25,7 @@ async def update_page(page_id: str, page: page_schema.PageSchema, user_info: dic
 
 @router.delete("/{page_id}", response_model=page_schema.DeletePageResponse, summary="Delete a page by its ID")
 async def delete_page(page_id: str, user_info: dict = Depends(check_role(["customization"]))):
-    deleted = await page_model.delete_page(page_id)
+    deleted = await page_service.delete_page(page_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Error deleting page")
     return {"page_id": page_id}
@@ -35,7 +33,7 @@ async def delete_page(page_id: str, user_info: dict = Depends(check_role(["custo
 
 @router.get("/{page_id}", response_model=page_schema.PageResponse, summary="Get a page by its ID")
 async def get_page(page_id: str):
-    page = await page_model.get_page(page_id)
+    page = await page_service.get_page(page_id)
     if not page:
         raise HTTPException(status_code=404, detail="Error getting page")
     return {"page_id": page_id, "title": page["title"], "components": page["components"]}
@@ -44,8 +42,8 @@ async def get_page(page_id: str):
 @router.post("/{page_id}/components", response_model=page_schema.BaseComponentSchema, summary="Add a new component to the page")
 async def add_component(page_id: str, component: page_schema.AddBaseComponentSchema, user_info: dict = Depends(check_role(["customization"]))):
     component_dict = component.dict()
-    component_dict['component_id'] = str(ObjectId())  # Gerando o component_id aqui
-    added = await page_model.add_component(page_id, component_dict)
+    component_dict['component_id'] = str(ObjectId())
+    added = await page_service.add_component(page_id, component_dict)
     if not added:
         raise HTTPException(status_code=404, detail="Error adding component")
     return {"name": component.name, "component_id": component_dict['component_id']}
@@ -53,7 +51,7 @@ async def add_component(page_id: str, component: page_schema.AddBaseComponentSch
 
 @router.delete("/{page_id}/components/{component_id}", response_model=page_schema.RemoveComponentResponse, summary="Remove a specific component")
 async def remove_component(page_id: str, component_id: str, user_info: dict = Depends(check_role(["customization"]))):
-    removed = await page_model.remove_component(page_id, component_id)
+    removed = await page_service.remove_component(page_id, component_id)
     if not removed:
         raise HTTPException(status_code=404, detail="Error removing component")
     return {"component_id": component_id}
@@ -61,7 +59,7 @@ async def remove_component(page_id: str, component_id: str, user_info: dict = De
 
 @router.put("/{page_id}/components/{component_id}", response_model=page_schema.BaseComponentSchema, summary="Update a specific component")
 async def update_component(page_id: str, component_id: str, updated_component: page_schema.AddBaseComponentSchema, user_info: dict = Depends(check_role(["customization"]))):
-    updated = await page_model.update_component(page_id, component_id, updated_component.dict())
+    updated = await page_service.update_component(page_id, component_id, updated_component.dict())
     if not updated:
         raise HTTPException(status_code=404, detail="Error updating component")
     return {"id": component_id, "name": updated_component.name}

--- a/services/ui/page_service.py
+++ b/services/ui/page_service.py
@@ -3,10 +3,11 @@ from bson import ObjectId
 from typing import List, Dict
 from dependencies.mongodb import db
 
-class PageModel:
+class PageService:
     def __init__(self, db: AsyncIOMotorDatabase):
         self.collection = db["pages"]
-    async def create_page(self, title: str, components: List[Dict]):
+
+    async def create_page(self, title: str, components: List[Dict]) -> str:
         for component in components:
             component['component_id'] = str(ObjectId())
         
@@ -14,7 +15,7 @@ class PageModel:
         result = await self.collection.insert_one(new_page)
         return str(result.inserted_id)
 
-    async def update_page(self, page_id: str, title: str, components: List[Dict]):
+    async def update_page(self, page_id: str, title: str, components: List[Dict]) -> bool:
         for component in components:
             if 'component_id' not in component:
                 component['component_id'] = str(ObjectId())
@@ -24,36 +25,37 @@ class PageModel:
         )
         return result.modified_count > 0
 
-    async def delete_page(self, page_id: str):
+    async def delete_page(self, page_id: str) -> bool:
         result = await self.collection.delete_one({"_id": ObjectId(page_id)})
         return result.deleted_count > 0
 
-    async def get_page(self, page_id: str):
+    async def get_page(self, page_id: str) -> Dict:
         page = await self.collection.find_one({"_id": ObjectId(page_id)})
         if page:
             page["_id"] = str(page["_id"])
         return page
 
-    async def add_component(self, page_id: str, component: Dict):
-        component["component_id"] = str(ObjectId())  # Gerar um ID único para o componente
+    async def add_component(self, page_id: str, component: Dict) -> bool:
+        component["component_id"] = str(ObjectId())  # Generate a unique ID for the component
         result = await self.collection.update_one(
             {"_id": ObjectId(page_id)},
             {"$push": {"components": component}}
         )
         return result.modified_count > 0
 
-    async def remove_component(self, page_id: str, component_id: str):
+    async def remove_component(self, page_id: str, component_id: str) -> bool:
         result = await self.collection.update_one(
             {"_id": ObjectId(page_id)},
             {"$pull": {"components": {"component_id": component_id}}}
         )
         return result.modified_count > 0
 
-    async def update_component(self, page_id: str, component_id: str, updated_component: Dict):
+    async def update_component(self, page_id: str, component_id: str, updated_component: Dict) -> bool:
         result = await self.collection.update_one(
             {"_id": ObjectId(page_id), "components.component_id": component_id},
             {"$set": {"components.$": updated_component}}
         )
         return result.modified_count > 0
 
-page_model = PageModel(db)
+# Initialize the service with the database dependency
+page_service = PageService(db)


### PR DESCRIPTION
Add color_theme model, schema, and routes (behaves as a singleton)
This pull request refactors the `routes/ui/page.py` file to use a new `page_service` instead of the old `page_model`. The changes involve renaming the model to a service, updating the file imports, and modifying the function calls accordingly.

Key changes include:

### Refactoring to use `page_service`:

* Updated imports in `routes/ui/page.py` to replace `page_model` with `page_service`.
* Modified all function calls in `routes/ui/page.py` to use `page_service` instead of `page_model` for creating, updating, deleting, and fetching pages and components. [[1]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L14-R36) [[2]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L47-R62)

### Service class updates:

* Renamed `PageModel` to `PageService` in the renamed file `services/ui/page_service.py`.
* Added return type annotations to methods in `PageService` to improve type safety and clarity.

These changes collectively improve the code structure by separating concerns and enhancing maintainability.