### PR TITLE
only list roles with coffeebreak prefix

### DIFF
--- a/services/user_service.py
+++ b/services/user_service.py
@@ -11,8 +11,13 @@ async def list_users() -> List[dict]:
     
 async def list_roles() -> List:
     try:
+        # Fetch all roles
         roles = keycloak_admin.get_realm_roles()
-        return roles
+        
+        # Filter roles with "cb-" prefix
+        filtered_roles = [role for role in roles if role["name"].startswith("cb-")]
+        
+        return filtered_roles
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to list roles: {str(e)}")
     


### PR DESCRIPTION
This pull request includes an enhancement to the `list_roles` function in the `services/user_service.py` file. The primary change is the addition of filtering logic to only return roles with a specific prefix.

Improvements to `list_roles` function:

* Added a comment to describe the fetching of all roles.
* Introduced filtering of roles to include only those with the "cb-" prefix before returning the list.