### PR TITLE
Fix Keycloak client lib implementation to handle urls with prefix

### DIFF
--- a/dependencies/auth.py
+++ b/dependencies/auth.py
@@ -1,11 +1,28 @@
+from keycloak import connection
+def custom_urljoin(a, b):
+    # If 'a' ends with a slash and 'b' starts with one, remove one slash
+    if a.endswith('/') and b.startswith('/'):
+        return a + b[1:]
+    # If 'a' doesn't end with a slash and 'b' starts with one, add a slash between them
+    elif not a.endswith('/') and b.startswith('/'):
+        return a + b
+    # If 'a' ends with a slash and 'b' doesn't start with one, just concatenate
+    elif a.endswith('/') and not b.startswith('/'):
+        return a + b
+    # If neither ends or starts with a slash, add one between them
+    else:
+        return a + '/' + b
+connection.urljoin = custom_urljoin
 from keycloak import KeycloakAdmin, KeycloakOpenID
 from fastapi import Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer
 import os
 import logging
 import sys
+import requests
 
 logger = logging.getLogger("coffeebreak.core")
+
 
 # Keycloak configuration
 KEYCLOAK_URL = os.getenv("KEYCLOAK_URL")
@@ -16,6 +33,8 @@ KEYCLOAK_CLIENT_SECRET = os.getenv("KEYCLOAK_CLIENT_SECRET")
 if not all([KEYCLOAK_URL, KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID, KEYCLOAK_CLIENT_SECRET]):
     logger.error("One or more Keycloak environment variables are not set. Exiting program.")
     raise sys.exit(1)
+
+logger.info(f'Connecting with keycloak at: {KEYCLOAK_URL}')
 
 # Initialize Keycloak OpenID (for authentication)
 keycloak_openid = KeycloakOpenID(

--- a/main.py
+++ b/main.py
@@ -96,7 +96,7 @@ plugin_loader('plugins', routes_app)
 Base.metadata.create_all(bind=engine) # should only be called after all plugins being loaded
 
 # Include all routers from routes/__init__.py
-app.include_router(routes_app, prefix="/api/v1")
+app.include_router(routes_app)
 
 # Run with: uvicorn main:app --reload --log-config logging_config.json
 # load env file: --env-file <env_file>

--- a/swagger.py
+++ b/swagger.py
@@ -1,6 +1,11 @@
 from fastapi.openapi.utils import get_openapi
+import os
+
+# Get the API prefix from the environment variables
+API_PREFIX = os.getenv("API_PREFIX", "/api/v1")  # Default to "/api/v1" if not set
 
 def configure_swagger_ui(app):
+    app.openapi_url = f"{API_PREFIX}/openapi.json"
     app.openapi_schema = get_openapi(
         title="Your API",
         version="1.0.0",
@@ -11,7 +16,7 @@ def configure_swagger_ui(app):
         "type": "oauth2",
         "flows": {
             "password": {
-                "tokenUrl": "/api/v1/token",
+                "tokenUrl": f"{API_PREFIX}/token",
                 "scopes": {},
             }
         },


### PR DESCRIPTION
The Keycloak client library, when joining two urls, removes the prefix included in the base_url.
Ex.: http://example.com/first + /second results in http://example.com/second

To handle keycloak deployment prefix one customized implementation was made. 