### PR TITLE
Invalid Mongo _id does not break code

### DIFF
--- a/routes/ui/page.py
+++ b/routes/ui/page.py
@@ -36,7 +36,7 @@ async def list_pages():
     pages = await page_service.list_pages()
     return [
         {
-            "page_id": page["_id"],
+            "page_id": page["id"],
             "title": page["title"],
             "components": page["components"]
         }
@@ -48,8 +48,11 @@ async def get_page(page_id: str):
     page = await page_service.get_page(page_id)
     if not page:
         raise HTTPException(status_code=404, detail="Error getting page")
-    return {"page_id": page_id, "title": page["title"], "components": page["components"]}
-
+    return {
+        "page_id": page["id"],
+        "title": page["title"],
+        "components": page["components"]
+    }
 
 @router.post("/{page_id}/components", response_model=page_schema.BaseComponentSchema, summary="Add a new component to the page")
 async def add_component(page_id: str, component: page_schema.AddBaseComponentSchema, user_info: dict = Depends(check_role(["customization"]))):
@@ -74,4 +77,4 @@ async def update_component(page_id: str, component_id: str, updated_component: p
     updated = await page_service.update_component(page_id, component_id, updated_component.dict())
     if not updated:
         raise HTTPException(status_code=404, detail="Error updating component")
-    return {"id": component_id, "name": updated_component.name}
+    return {"component_id": component_id, "name": updated_component.name}

--- a/services/ui/page_service.py
+++ b/services/ui/page_service.py
@@ -2,6 +2,7 @@ from motor.motor_asyncio import AsyncIOMotorDatabase
 from bson import ObjectId
 from typing import List, Dict
 from dependencies.mongodb import db
+from utils.mongoserializer import to_object_id, from_mongo
 
 class PageService:
     def __init__(self, db: AsyncIOMotorDatabase):
@@ -10,7 +11,7 @@ class PageService:
     async def create_page(self, title: str, components: List[Dict]) -> str:
         for component in components:
             component['component_id'] = str(ObjectId())
-        
+
         new_page = {"title": title, "components": components}
         result = await self.collection.insert_one(new_page)
         return str(result.inserted_id)
@@ -20,47 +21,44 @@ class PageService:
             if 'component_id' not in component:
                 component['component_id'] = str(ObjectId())
         result = await self.collection.update_one(
-            {"_id": ObjectId(page_id)},
+            {"_id": to_object_id(page_id)},
             {"$set": {"title": title, "components": components}}
         )
         return result.modified_count > 0
 
     async def delete_page(self, page_id: str) -> bool:
-        result = await self.collection.delete_one({"_id": ObjectId(page_id)})
+        result = await self.collection.delete_one({"_id": to_object_id(page_id)})
         return result.deleted_count > 0
-    
+
     async def list_pages(self):
         cursor = self.collection.find()
         pages = []
         async for page in cursor:
-            page["_id"] = str(page["_id"])
-            pages.append(page)
+            pages.append(from_mongo(page))
         return pages
 
     async def get_page(self, page_id: str) -> Dict:
-        page = await self.collection.find_one({"_id": ObjectId(page_id)})
-        if page:
-            page["_id"] = str(page["_id"])
-        return page
+        page = await self.collection.find_one({"_id": to_object_id(page_id)})
+        return from_mongo(page) if page else None
 
     async def add_component(self, page_id: str, component: Dict) -> bool:
         component["component_id"] = str(ObjectId())  # Generate a unique ID for the component
         result = await self.collection.update_one(
-            {"_id": ObjectId(page_id)},
+            {"_id": to_object_id(page_id)},
             {"$push": {"components": component}}
         )
         return result.modified_count > 0
 
     async def remove_component(self, page_id: str, component_id: str) -> bool:
         result = await self.collection.update_one(
-            {"_id": ObjectId(page_id)},
+            {"_id": to_object_id(page_id)},
             {"$pull": {"components": {"component_id": component_id}}}
         )
         return result.modified_count > 0
 
     async def update_component(self, page_id: str, component_id: str, updated_component: Dict) -> bool:
         result = await self.collection.update_one(
-            {"_id": ObjectId(page_id), "components.component_id": component_id},
+            {"_id": to_object_id(page_id), "components.component_id": component_id},
             {"$set": {"components.$": updated_component}}
         )
         return result.modified_count > 0

--- a/utils/mongoserializer.py
+++ b/utils/mongoserializer.py
@@ -1,0 +1,24 @@
+from bson import ObjectId
+from typing import Any, Dict
+from fastapi import HTTPException
+
+
+def to_object_id(id_str: str) -> ObjectId:
+    """
+    Converts a string ID to ObjectId, raising HTTPException if invalid.
+    """
+    try:
+        return ObjectId(id_str)
+    except Exception:
+        raise HTTPException(status_code=400, detail=f"'{id_str}' is not a valid ObjectId")
+
+
+def from_mongo(document: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Convert MongoDB document (_id) to JSON-friendly format (id).
+    """
+    if not document:
+        return document
+    document = document.copy()
+    document["id"] = str(document.pop("_id"))
+    return document

--- a/utils/mongoserializer.py
+++ b/utils/mongoserializer.py
@@ -1,7 +1,7 @@
 from bson import ObjectId
-from typing import Any, Dict
+from bson.errors import InvalidId
 from fastapi import HTTPException
-
+from typing import Dict, Any
 
 def to_object_id(id_str: str) -> ObjectId:
     """
@@ -9,9 +9,8 @@ def to_object_id(id_str: str) -> ObjectId:
     """
     try:
         return ObjectId(id_str)
-    except Exception:
+    except InvalidId:
         raise HTTPException(status_code=400, detail=f"'{id_str}' is not a valid ObjectId")
-
 
 def from_mongo(document: Dict[str, Any]) -> Dict[str, Any]:
     """


### PR DESCRIPTION
This pull request includes several changes to improve the handling of MongoDB ObjectIds and JSON serialization in the `ui` routes and services. The most important changes are the introduction of utility functions for ObjectId conversion and the consistent use of these functions across the codebase.

### Improvements to MongoDB ObjectId handling and JSON serialization:

* [`routes/ui/page.py`](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L39-R39): Updated the `page_id` field to use `page["id"]` instead of `page["_id"]` in the `list_pages`, `get_page`, and `update_component` functions. [[1]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L39-R39) [[2]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L51-R55) [[3]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L77-R80)

* [`services/ui/page_service.py`](diffhunk://#diff-b6c2f2dad2ac2da52f8cea0a7bf4753ce186004ec808380b6ccbd0f3144bc3baL23-R61): Replaced direct usage of `ObjectId` with the new `to_object_id` utility function for conversions in various methods, including `update_page`, `delete_page`, `add_component`, `remove_component`, and `update_component`. Added the `from_mongo` utility function to convert MongoDB documents to a JSON-friendly format.

* [`utils/mongoserializer.py`](diffhunk://#diff-3505e85d11ee316386ffe7d1de51db329e6254bb3488176c5dc4b4e7961e8597R1-R24): Introduced the `to_object_id` function to convert string IDs to `ObjectId`, raising an `HTTPException` if the conversion fails. Added the `from_mongo` function to convert MongoDB documents to a JSON-friendly format by replacing `_id` with `id`.