### PR TITLE
Add Media Service for file upload systems

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -8,8 +8,42 @@ from schemas.ui.components.image import Image
 from schemas.ui.components.text import Text
 from schemas.ui.components.button import Button
 from services.component_registry import ComponentRegistry
+from services.media import MediaService
+from repository.media import LocalMediaRepo
+from models.media import Media
+import os
+from sqlalchemy.orm import Session
+from dependencies.database import get_db
 
 logger = logging.getLogger("coffeebreak")
+
+MEDIA_ROOT = os.path.join(os.path.dirname(__file__), 'media')
+MediaService.set_repository(lambda: LocalMediaRepo(MEDIA_ROOT))
+
+
+async def create_default_test_media(db: Session):
+    """Creates a default media entity for testing if it doesn't exist"""
+    try:
+        # Check if test media already exists
+        existing = db.query(Media).filter(Media.alias == 'test-image').first()
+        if existing:
+            logger.debug(
+                f"Test media already exists with UUID: {existing.uuid}")
+            return existing
+
+        # Register a media entity that only accepts images
+        media = MediaService.register(
+            db,
+            max_size=5 * 1024 * 1024,  # 5MB
+            allows_rewrite=True,
+            valid_extensions=['.jpg', '.jpeg', '.png', '.gif', '.webp'],
+            alias='test-image'
+        )
+        logger.debug(f"Created default test media with UUID: {media.uuid}")
+        return media
+    except Exception as e:
+        logger.error(f"Error creating default test media: {e}")
+        return None
 
 
 async def create_default_main_menu():
@@ -125,6 +159,7 @@ async def create_default_color_theme():
         )
         await color_themes_collection.insert_one(default_color_theme.model_dump())
 
+
 async def register_default_components():
     """Register default components"""
     component_registry = ComponentRegistry()
@@ -141,6 +176,12 @@ async def register_default_components():
 async def initialize_defaults():
     """Initialize all default data"""
     logger.info("Initializing default data...")
+
+    # Initialize SQL defaults
+    db = next(get_db())
+    await create_default_test_media(db)
+
+    # Initialize MongoDB defaults
     await create_default_main_menu()
     await register_default_components()
     await create_default_pages()

--- a/models/media.py
+++ b/models/media.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column, String, Integer, Boolean, JSON
+from dependencies.database import Base
+
+
+class Media(Base):
+    """
+    Entity for managing media files metadata
+    """
+    __tablename__ = 'media'
+
+    uuid = Column(String, primary_key=True)
+    max_size = Column(Integer, nullable=True)
+    hash = Column(String, nullable=True)
+    alias = Column(String, nullable=True)
+    valid_extensions = Column(JSON, default=list)
+    allow_rewrite = Column(Boolean, default=True)
+    op_required = Column(Boolean, default=False)
+
+    def __repr__(self):
+        return f"<Media(uuid='{self.uuid}', alias='{self.alias}', hash='{self.hash}')>"

--- a/repository/media.py
+++ b/repository/media.py
@@ -1,0 +1,94 @@
+from abc import ABC, abstractmethod
+import os
+import shutil
+from typing import BinaryIO
+
+
+class BaseMediaRepo(ABC):
+    """
+    Abstract base class for media repositories
+    """
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    @abstractmethod
+    def save(self, hash: str, data: BinaryIO) -> None:
+        """Save media data with given hash"""
+        pass
+
+    @abstractmethod
+    def read(self, hash: str) -> BinaryIO:
+        """Read media data for given hash"""
+        pass
+
+    @abstractmethod
+    def remove(self, hash: str) -> None:
+        """Remove media data for given hash"""
+        pass
+
+
+class LocalMediaRepo(BaseMediaRepo):
+    """
+    Local filesystem implementation of media repository
+    """
+
+    def __init__(self, root_path: str):
+        self.root_path = root_path
+        os.makedirs(root_path, exist_ok=True)
+
+    def _get_file_path(self, hash: str) -> str:
+        """Get the full path for a file based on its hash"""
+        dir1, dir2 = hash[0:2], hash[2:4]
+        return os.path.join(self.root_path, dir1, dir2, hash)
+
+    def _ensure_dir_exists(self, hash: str) -> None:
+        """Ensure the directory structure exists for given hash"""
+        dir1, dir2 = hash[0:2], hash[2:4]
+        os.makedirs(os.path.join(self.root_path, dir1, dir2), exist_ok=True)
+
+    def save(self, hash: str, data: BinaryIO) -> None:
+        """
+        Save media data to local filesystem
+
+        Args:
+            hash: File hash to use as identifier
+            data: File-like object containing the data to save
+        """
+        self._ensure_dir_exists(hash)
+        file_path = self._get_file_path(hash)
+
+        with open(file_path, 'wb') as f:
+            shutil.copyfileobj(data, f)
+
+    def read(self, hash: str) -> BinaryIO:
+        """
+        Read media data from local filesystem
+
+        Args:
+            hash: File hash to read
+
+        Returns:
+            File-like object containing the media data
+
+        Raises:
+            FileNotFoundError: If file doesn't exist
+        """
+        file_path = self._get_file_path(hash)
+        return open(file_path, 'rb')
+
+    def remove(self, hash: str) -> None:
+        """
+        Remove media data from local filesystem
+
+        Args:
+            hash: File hash to remove
+
+        Raises:
+            FileNotFoundError: If file doesn't exist
+        """
+        file_path = self._get_file_path(hash)
+        os.remove(file_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ pytest-cov==6.0.0
 python-dotenv==1.0.1
 python-json-logger==3.2.1
 python-keycloak==5.3.1
+python-magic==0.4.27
 python-multipart==0.0.20
 qrcode==8.0
 requests==2.32.3

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from . import users, activities, activity_types, auth, plugins, totp, notifications
+from . import users, activities, activity_types, auth, plugins, totp, notifications, media
 from .ui import color_themes, page, main_menu, plugin_settings
 from .components import router as components_router
 
@@ -18,6 +18,7 @@ routes_app.include_router(plugins.router, prefix="/plugins", tags=["Plugins"])
 routes_app.include_router(totp.router, prefix="/totp", tags=["TOTP"])
 routes_app.include_router(notifications.router,
                           prefix="/notifications", tags=["Notifications"])
+routes_app.include_router(media.router, prefix="/media", tags=["Media"])
 
 # Include UI routers
 routes_app.include_router(main_menu.router, prefix="/ui/menu", tags=["UI"])

--- a/routes/media.py
+++ b/routes/media.py
@@ -1,0 +1,72 @@
+from fastapi import APIRouter, Depends, UploadFile, File, Response
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+from typing import Optional
+import magic
+
+from dependencies.database import get_db
+from dependencies.auth import get_current_user
+from services.media import MediaService
+from schemas.media import MediaResponse
+
+router = APIRouter()
+
+
+@router.post("/{uuid}", response_model=MediaResponse)
+async def upload_media(
+    uuid: str,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    user: Optional[dict] = Depends(lambda: get_current_user(force_auth=False))
+):
+    """Upload a new media file"""
+    return MediaService.create(db, uuid, file.file, file.filename, user)
+
+
+@router.get("/{uuid}")
+async def download_media(
+    uuid: str,
+    db: Session = Depends(get_db)
+):
+    """Download a media file"""
+    media, data = MediaService.read(db, uuid)
+
+    # Read first chunk to detect MIME type
+    chunk = data.read(2048)
+    mime = magic.from_buffer(chunk, mime=True)
+    data.seek(0)  # Reset file pointer
+
+    # Determine if content should be displayed inline or downloaded
+    content_disposition = "attachment"
+    if mime.startswith(('image/', 'video/')):
+        content_disposition = "inline"
+
+    return StreamingResponse(
+        data,
+        media_type=mime,
+        headers={
+            "Content-Disposition": f'{content_disposition}; filename="{media.alias}"'
+        }
+    )
+
+
+@router.put("/{uuid}", response_model=MediaResponse)
+async def update_media(
+    uuid: str,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    user: Optional[dict] = Depends(lambda: get_current_user(force_auth=False))
+):
+    """Update an existing media file"""
+    return MediaService.create_or_replace(db, uuid, file.file, file.filename, user)
+
+
+@router.delete("/{uuid}")
+async def delete_media(
+    uuid: str,
+    db: Session = Depends(get_db),
+    user: Optional[dict] = Depends(lambda: get_current_user(force_auth=False))
+):
+    """Delete a media file"""
+    MediaService.remove(db, uuid, user)
+    return {"message": "Media deleted successfully"}

--- a/schemas/media.py
+++ b/schemas/media.py
@@ -1,0 +1,32 @@
+from typing import Optional, List
+from pydantic import BaseModel, Field
+
+
+class MediaBase(BaseModel):
+    """
+    Base schema for media attributes
+    """
+    max_size: Optional[int] = None
+    alias: Optional[str] = None
+    valid_extensions: List[str] = Field(default_factory=list)
+    allow_rewrite: bool = True
+    op_required: bool = False
+
+
+class MediaCreate(MediaBase):
+    """
+    Schema for creating new media registration
+    """
+    pass
+
+
+class MediaResponse(MediaBase):
+    """
+    Schema for media response
+    """
+    uuid: str
+    hash: Optional[str] = None
+
+    class Config:
+        """Configure Pydantic to read data from ORM"""
+        from_attributes = True

--- a/services/media.py
+++ b/services/media.py
@@ -1,0 +1,344 @@
+import hashlib
+import uuid
+import os
+from typing import Optional, List, BinaryIO, Type
+from sqlalchemy.orm import Session
+from fastapi import HTTPException, UploadFile
+
+from models.media import Media
+from repository.media import BaseMediaRepo
+from dependencies.auth import get_current_user
+
+
+class MediaService:
+    """
+    Service for managing media files
+    """
+    _repository: Optional[Type[BaseMediaRepo]] = None
+
+    @classmethod
+    def set_repository(cls, repository_factory):
+        """Set the repository factory to be used by the service"""
+        cls._repository = repository_factory()
+
+    @classmethod
+    def _get_repository(cls) -> BaseMediaRepo:
+        """Get repository instance, raising error if not configured"""
+        if cls._repository is None:
+            raise RuntimeError("Media repository not configured")
+        return cls._repository
+
+    @staticmethod
+    def _compute_hash(data: BinaryIO) -> str:
+        """Compute SHA-256 hash of file data"""
+        sha256 = hashlib.sha256()
+        for chunk in iter(lambda: data.read(4096), b''):
+            sha256.update(chunk)
+        data.seek(0)  # Reset file pointer
+        return sha256.hexdigest()
+
+    @staticmethod
+    def _validate_file(media: Media, file: BinaryIO, filename: str) -> None:
+        """
+        Validate file size and extension
+
+        Args:
+            media: Media entity with validation rules
+            file: File data to validate
+            filename: Original filename to check extension
+
+        Raises:
+            HTTPException: If validation fails
+        """
+        # Validate file size if max_size is set
+        if media.max_size:
+            file.seek(0, 2)  # Seek to end
+            size = file.tell()
+            file.seek(0)  # Reset pointer
+            if size > media.max_size:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"File exceeds maximum size of {media.max_size} bytes"
+                )
+
+        # Validate extension if valid_extensions is set
+        if media.valid_extensions:
+            _, ext = os.path.splitext(filename)
+            if not ext:
+                raise HTTPException(
+                    status_code=400,
+                    detail="File has no extension"
+                )
+            if ext.lower() not in [ext.lower() for ext in media.valid_extensions]:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid file extension. Allowed extensions: {', '.join(media.valid_extensions)}"
+                )
+
+    @classmethod
+    def register(
+        cls,
+        db: Session,
+        max_size: Optional[int] = None,
+        allows_rewrite: bool = True,
+        valid_extensions: List[str] = None,
+        alias: Optional[str] = None
+    ) -> Media:
+        """
+        Register a new media entity
+
+        Args:
+            db: Database session
+            max_size: Maximum allowed file size in bytes
+            allows_rewrite: Whether file can be replaced
+            valid_extensions: List of allowed file extensions (e.g. ['.jpg', '.png'])
+            alias: Optional alias for the media
+
+        Returns:
+            Created Media entity
+        """
+        media = Media(
+            uuid=str(uuid.uuid4()),
+            max_size=max_size,
+            hash=None,
+            alias=alias,
+            valid_extensions=valid_extensions or [],
+            allow_rewrite=allows_rewrite
+        )
+        db.add(media)
+        db.commit()
+        db.refresh(media)
+        return media
+
+    @classmethod
+    def create(cls, db: Session, uuid: str, data: BinaryIO, filename: str, user: Optional[dict] = None) -> Media:
+        """
+        Create new media file
+
+        Args:
+            db: Database session
+            uuid: Media UUID
+            data: File data
+            filename: Original filename for extension validation
+            user: Optional user info for authorization
+
+        Returns:
+            Updated Media entity
+
+        Raises:
+            HTTPException: If validation fails
+        """
+        media = db.query(Media).filter(Media.uuid == uuid).first()
+        if not media:
+            raise HTTPException(status_code=404, detail="Media not found")
+
+        if media.hash is not None:
+            raise HTTPException(status_code=400, detail="Media already exists")
+
+        if media.op_required and (not user or 'media_op' not in user.get('roles', [])):
+            raise HTTPException(
+                status_code=403, detail="Operation requires media_op role")
+
+        # Validate file size and extension
+        cls._validate_file(media, data, filename)
+
+        # Set alias as filename if not already set
+        if not media.alias:
+            media.alias = filename
+
+        # Compute and save hash
+        file_hash = cls._compute_hash(data)
+        media.hash = file_hash
+
+        try:
+            # Save file first
+            cls._get_repository().save(file_hash, data)
+
+            try:
+                # Then try to commit database changes
+                db.commit()
+                return media
+            except Exception as db_error:
+                # If database commit fails, remove the saved file
+                try:
+                    cls._get_repository().remove(file_hash)
+                except Exception:
+                    pass  # Ignore cleanup errors
+                db.rollback()
+                raise db_error
+        except Exception as e:
+            db.rollback()
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @classmethod
+    def read(cls, db: Session, uuid: str) -> tuple[Media, BinaryIO]:
+        """
+        Read media file
+
+        Args:
+            db: Database session
+            uuid: Media UUID
+
+        Returns:
+            Tuple of (Media entity, file data)
+
+        Raises:
+            HTTPException: If media not found or has no data
+        """
+        media = db.query(Media).filter(Media.uuid == uuid).first()
+        if not media or not media.hash:
+            raise HTTPException(status_code=404, detail="Media not found")
+
+        try:
+            data = cls._get_repository().read(media.hash)
+            return media, data
+        except FileNotFoundError:
+            raise HTTPException(status_code=404, detail="Media file not found")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @classmethod
+    def create_or_replace(cls, db: Session, uuid: str, data: BinaryIO, filename: str, user: Optional[dict] = None) -> Media:
+        """
+        Create or replace media file
+
+        Args:
+            db: Database session
+            uuid: Media UUID
+            data: New file data
+            filename: Original filename for extension validation
+            user: Optional user info for authorization
+
+        Returns:
+            Updated Media entity
+
+        Raises:
+            HTTPException: If validation fails
+        """
+        media = db.query(Media).filter(Media.uuid == uuid).first()
+        if not media:
+            raise HTTPException(status_code=404, detail="Media not found")
+
+        if not media.allow_rewrite:
+            raise HTTPException(
+                status_code=403, detail="Media does not allow rewrite")
+
+        if media.op_required and (not user or 'media_op' not in user.get('roles', [])):
+            raise HTTPException(
+                status_code=403, detail="Operation requires media_op role")
+
+        # Validate file size and extension
+        cls._validate_file(media, data, filename)
+
+        # Set alias as filename if not already set
+        if not media.alias:
+            media.alias = filename
+
+        # Store old state for rollback
+        old_hash = media.hash
+
+        # Compute new hash
+        new_hash = cls._compute_hash(data)
+        media.hash = new_hash
+
+        try:
+            # Save new file first
+            cls._get_repository().save(new_hash, data)
+
+            try:
+                # Try to commit database changes
+                db.commit()
+
+                # If successful, remove old file if it exists
+                if old_hash:
+                    try:
+                        cls._get_repository().remove(old_hash)
+                    except FileNotFoundError:
+                        pass  # Ignore if old file doesn't exist
+
+                return media
+            except Exception as db_error:
+                # If database commit fails:
+                # 1. Remove the new file
+                try:
+                    cls._get_repository().remove(new_hash)
+                except Exception:
+                    pass  # Ignore cleanup errors
+
+                # 2. Restore database state
+                db.rollback()
+                raise db_error
+        except Exception as e:
+            # Restore database state
+            db.rollback()
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @classmethod
+    def remove(cls, db: Session, uuid: str, user: Optional[dict] = None) -> None:
+        """
+        Remove media file
+
+        Args:
+            db: Database session
+            uuid: Media UUID
+            user: Optional user info for authorization
+
+        Raises:
+            HTTPException: If validation fails
+        """
+        media = db.query(Media).filter(Media.uuid == uuid).first()
+        if not media:
+            raise HTTPException(status_code=404, detail="Media not found")
+
+        if not media.allow_rewrite:
+            raise HTTPException(
+                status_code=403, detail="Media does not allow deletion")
+
+        if media.op_required and (not user or 'media_op' not in user.get('roles', [])):
+            raise HTTPException(
+                status_code=403, detail="Operation requires media_op role")
+
+        if media.hash:
+            try:
+                cls._get_repository().remove(media.hash)
+                media.hash = None
+                db.commit()
+            except FileNotFoundError:
+                pass  # Ignore if file doesn't exist
+            except Exception as e:
+                db.rollback()
+                raise HTTPException(status_code=500, detail=str(e))
+
+    @classmethod
+    def unregister(cls, db: Session, uuid: str, force: bool = False) -> None:
+        """
+        Unregister media entity
+
+        Args:
+            db: Database session
+            uuid: Media UUID
+            force: Whether to force deletion even if file exists
+
+        Raises:
+            HTTPException: If validation fails
+        """
+        media = db.query(Media).filter(Media.uuid == uuid).first()
+        if not media:
+            raise HTTPException(status_code=404, detail="Media not found")
+
+        if media.hash and not force:
+            raise HTTPException(
+                status_code=400, detail="Cannot unregister media with existing file")
+
+        try:
+            if media.hash:
+                try:
+                    cls._get_repository().remove(media.hash)
+                except FileNotFoundError:
+                    pass  # Ignore if file doesn't exist
+
+            db.delete(media)
+            db.commit()
+        except Exception as e:
+            db.rollback()
+            raise HTTPException(status_code=500, detail=str(e))

--- a/swagger.py
+++ b/swagger.py
@@ -35,11 +35,6 @@ def configure_swagger_ui(app):
         }
     }
 
-    # Add security requirement to all endpoints by default
-    app.openapi_schema["security"] = [
-        {"OAuth2PasswordBearer": []}
-    ]
-
     app.openapi = lambda: app.openapi_schema
 
     # Configure Swagger UI initialization


### PR DESCRIPTION
### File Upload

Implementar estruturas no Core que depois podem ser utilizadas pelos plugins para fazer upload de imagens:
entities.media: uuid (pseudo-random), max_size, hash, alias (string), validExtensions (JSON-List-Strings), allow_rewrite (bool), op_required (bool) 

controllers.media: all methods call service methods
POST: /media/{uuid} upload a new file. 
GET: /media/{uuid} download a file
PUT: /media/{uuid} upload a new file, or replace if already exists
DELETE: /media/{uuid} delete a new file

services.media:
setRepository: stores a Repository class in a variable to be used to instantiate repository in others methods on this service
register(max_size=None, allows_rewrite=True, validExtensions=[], alias=None) : insert a new Media entity, with hash null. 
create(uuid, data) : verify if: uuid exists, hash is None and, if op required, verify if it's aithenticated and has role media_op. Compute hash and store on Entity. Call repository save(hash, data) method
read(uuid) : verify if uuid & hash exists. Call repository read(hash) -> data method
create_or_replace(uuid, data) : Similar to create but: requires allow_rewrite; don't requires hash None. Compute new hash and store on Entity. Calls repository save(newHash, data) method after remove(oldHash) 
remove(uuid) : Same verifications of create_or_replace. Calls repository remove(hash) and hash turns None. 
unregister(uuid, force=False) : only if hash is None or force is True. If hash isn't None, call repository remove(hash). Remove entity

repository.BaseMediaRepo: abstract: Singleton
abstract methods:
save(hash,data) 
read(hash) 
remove(hash) 

repository.LocalMediaRepo: implement BaseMediaRepo
constructor receives the repository root_path
files are stored in: root_path/{hash[0:2]}/{hash[2:4]}/hash to be more efficient than stores all files in the same directory
In defaults.py, call: setRepository(lambda: LocalMediaRepo("path_to_volume"))