### PR TITLE
Scrum 172 event data api endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 __pycache__/
 *.db
 
+# Media files
+media/
 
 ### macOS ###
 # General

--- a/defaults.py
+++ b/defaults.py
@@ -39,6 +39,8 @@ async def create_default_pages():
         # Create home page with Welcome component
         home_page = Page(
             title="Home",
+            description="Welcome to the home page",
+            enabled=True,
             components=[
                 {
                     "name": "Welcome"
@@ -51,6 +53,8 @@ async def create_default_pages():
         # Create profile page with UserProfile component
         profile_page = Page(
             title="Profile",
+            description="User profile page",
+            enabled=True,
             components=[
                 {
                     "name": "User Profile"
@@ -86,6 +90,8 @@ async def create_default_pages():
 
         activity_page = Page(
             title="Activity",
+            description="Activity page with multiple components",
+            enabled=True,
             components=[
                 title_component.model_dump(),
                 image_component.model_dump(),

--- a/models/event_info.py
+++ b/models/event_info.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String, DateTime, JSON, ForeignKey
+from sqlalchemy.orm import relationship
+from dependencies.database import Base
+
+class Event(Base):
+    __tablename__ = "event_info"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    description = Column(String, nullable=True)
+    start_time = Column(DateTime, nullable=True)
+    end_time = Column(DateTime, nullable=True)
+    location = Column(String, nullable=True)
+    
+    # Change from direct image storage to media reference
+    image_id = Column(String, ForeignKey("media.uuid"), nullable=True)
+    image = relationship("Media")

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from . import users, activities, activity_types, auth, plugins, totp, notifications, media
+from . import users, activities, activity_types, auth, plugins, totp, notifications, media, event_info
 from .ui import color_themes, page, main_menu, plugin_settings
 from .components import router as components_router
 
@@ -7,6 +7,8 @@ from .components import router as components_router
 routes_app = APIRouter()
 
 # Include all routers
+routes_app.include_router(event_info.router,
+                          prefix="/event-info", tags=["Event Information"])
 routes_app.include_router(users.router, prefix="/users", tags=["Users"])
 routes_app.include_router(
     activities.router, prefix="/activities", tags=["Activities"])

--- a/routes/event_info.py
+++ b/routes/event_info.py
@@ -1,0 +1,158 @@
+from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Request
+from sqlalchemy.orm import Session
+from typing import Optional
+
+from dependencies.database import get_db
+from dependencies.auth import check_role
+from models.event_info import Event as EventInfoModel
+from schemas.event_info import EventInfo, EventInfoCreate, EventInfoBase
+from services.media import MediaService
+
+router = APIRouter()
+
+# Helper to build image URL
+def get_image_url(request: Request, media_uuid: str) -> Optional[str]:
+    if not media_uuid:
+        return None
+    return f"{request.base_url}media/{media_uuid}"
+
+@router.get("/event", response_model=EventInfo, summary="Get current event information")
+async def get_event(request: Request, db: Session = Depends(get_db)):
+    """
+    Get information about the current event.
+    """
+    event = db.query(EventInfoModel).first()
+    if not event:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No event information found"
+        )
+    
+    # Create response with image URL
+    response = EventInfo.model_validate(event)
+    if event.image_id:
+        response.image_url = get_image_url(request, event.image_id)
+    
+    return response
+
+@router.post("/event", response_model=EventInfo, status_code=status.HTTP_201_CREATED, summary="Create or update event information")
+async def create_or_update_event(
+    request: Request,
+    event: EventInfoCreate, 
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(check_role(["admin", "events_manager"]))
+):
+    """
+    Create or update the event information.
+    If event information already exists, it will be updated.
+    """
+    # Check if event already exists
+    existing_event = db.query(EventInfoModel).first()
+    
+    if existing_event:
+        # Update existing event
+        for key, value in event.model_dump().items():
+            setattr(existing_event, key, value)
+        db.commit()
+        db.refresh(existing_event)
+        
+        # Create response with image URL
+        response = EventInfo.model_validate(existing_event)
+        if existing_event.image_id:
+            response.image_url = get_image_url(request, existing_event.image_id)
+        
+        return response
+    else:
+        # Create new event
+        db_event = EventInfoModel(**event.model_dump())
+        db.add(db_event)
+        db.commit()
+        db.refresh(db_event)
+        
+        # Create response with image URL
+        response = EventInfo.model_validate(db_event)
+        if db_event.image_id:
+            response.image_url = get_image_url(request, db_event.image_id)
+        
+        return response
+
+@router.post("/event/image", response_model=EventInfo, summary="Upload event image")
+async def upload_event_image(
+    request: Request,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(check_role(["admin", "events_manager"]))
+):
+    """
+    Upload or update the event image.
+    """
+    # Get the current event
+    event = db.query(EventInfoModel).first()
+    if not event:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No event found. Create event first."
+        )
+    
+    # If there's already an image, prepare to replace it
+    if event.image_id:
+        # Use the existing media UUID
+        media_uuid = event.image_id
+        
+        # Update the existing media
+        MediaService.create_or_replace(db, media_uuid, file.file, file.filename)
+    else:
+        # Register new media with acceptable image extensions
+        media = MediaService.register(
+            db,
+            max_size=10 * 1024 * 1024,  # 10MB limit
+            allows_rewrite=True,
+            valid_extensions=['.jpg', '.jpeg', '.png', '.gif', '.webp'],
+            alias=file.filename
+        )
+        
+        # Store the media UUID
+        media_uuid = media.uuid
+        
+        # Create the actual media content
+        MediaService.create(db, media_uuid, file.file, file.filename)
+        
+        # Update the event with the new media UUID
+        event.image_id = media_uuid
+        db.commit()
+        db.refresh(event)
+    
+    # Create response with image URL
+    response = EventInfo.model_validate(event)
+    response.image_url = get_image_url(request, media_uuid)
+    
+    return response
+
+@router.delete("/event/image", response_model=EventInfo, summary="Delete event image")
+async def delete_event_image(
+    request: Request,
+    db: Session = Depends(get_db),
+    user_info: dict = Depends(check_role(["admin", "events_manager"]))
+):
+    """
+    Delete the event image.
+    """
+    # Get the current event
+    event = db.query(EventInfoModel).first()
+    if not event or not event.image_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No event image found."
+        )
+    
+    # Remove the media file
+    MediaService.remove(db, event.image_id, user_info)
+    
+    # Clear the image reference
+    event.image_id = None
+    db.commit()
+    db.refresh(event)
+    
+    # Return the updated event
+    response = EventInfo.model_validate(event)
+    return response

--- a/routes/event_info.py
+++ b/routes/event_info.py
@@ -5,16 +5,11 @@ from typing import Optional
 from dependencies.database import get_db
 from dependencies.auth import check_role
 from models.event_info import Event as EventInfoModel
-from schemas.event_info import EventInfo, EventInfoCreate, EventInfoBase, ImageUploadParams
+from schemas.event_info import EventInfo, EventInfoCreate
 from services.media import MediaService
 
 router = APIRouter()
 
-# Helper to build image URL
-def get_image_url(request: Request, media_uuid: str) -> Optional[str]:
-    if not media_uuid:
-        return None
-    return f"{request.base_url}media/{media_uuid}"
 
 @router.get("/event", response_model=EventInfo, summary="Get current event information")
 async def get_event(request: Request, db: Session = Depends(get_db)):
@@ -27,20 +22,16 @@ async def get_event(request: Request, db: Session = Depends(get_db)):
             status_code=status.HTTP_404_NOT_FOUND,
             detail="No event information found"
         )
-    
-    # Create response with image URL
-    response = EventInfo.model_validate(event)
-    if event.image_id:
-        response.image_url = get_image_url(request, event.image_id)
-    
-    return response
+
+    return EventInfo.model_validate(event)
+
 
 @router.post("/event", response_model=EventInfo, status_code=status.HTTP_201_CREATED, summary="Create or update event information")
 async def create_or_update_event(
     request: Request,
-    event: EventInfoCreate, 
+    event: EventInfoCreate,
     db: Session = Depends(get_db),
-    user_info: dict = Depends(check_role(["admin", "events_manager"]))
+    user_info: dict = Depends(check_role(["admin", "manage_event"]))
 ):
     """
     Create or update the event information.
@@ -48,102 +39,30 @@ async def create_or_update_event(
     """
     # Check if event already exists
     existing_event = db.query(EventInfoModel).first()
-    
+
     if existing_event:
         # Update existing event
         for key, value in event.model_dump().items():
             setattr(existing_event, key, value)
         db.commit()
         db.refresh(existing_event)
-        
-        # Create response with image URL
-        response = EventInfo.model_validate(existing_event)
-        if existing_event.image_id:
-            response.image_url = get_image_url(request, existing_event.image_id)
-        
-        return response
+        return EventInfo.model_validate(existing_event)
     else:
         # Create new event
-        db_event = EventInfoModel(**event.model_dump())
+        event_dict = event.model_dump()
+
+        # Register media for image
+        media = MediaService.register(
+            db=db,
+            max_size=10 * 1024 * 1024,  # 10MB
+            allows_rewrite=True,
+            valid_extensions=['.jpg', '.jpeg', '.png', '.gif', '.webp'],
+            alias="event_image"
+        )
+
+        # Create event with media id
+        db_event = EventInfoModel(**event_dict, image_id=media.uuid)
         db.add(db_event)
         db.commit()
         db.refresh(db_event)
-        
-        # Create response with image URL
-        response = EventInfo.model_validate(db_event)
-        if db_event.image_id:
-            response.image_url = get_image_url(request, db_event.image_id)
-        
-        return response
-
-@router.post("/event/image", response_model=EventInfo)
-async def upload_event_image(
-    request: Request,
-    file: UploadFile = File(...),
-    params: ImageUploadParams = Depends(),
-    db: Session = Depends(get_db),
-    user_info: dict = Depends(check_role(["admin", "events_manager"]))
-):
-    """
-    Upload or update the event image.
-    """
-    # Get the current event
-    event = db.query(EventInfoModel).first()
-    if not event:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No event found. Create event first."
-        )
-    
-    # Use the existing media UUID
-    media_uuid = event.image_id
-    
-    # Validate file size and extension
-    if file.size > params.max_size:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"File size exceeds the maximum allowed size of {params.max_size} bytes."
-        )
-    if not any(file.filename.endswith(ext) for ext in params.allowed_extensions):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"File extension not allowed. Allowed extensions: {params.allowed_extensions}."
-        )
-    
-    # Update the existing media
-    MediaService.create_or_replace(db, media_uuid, file.file, file.filename)
-    
-    # Create response with image URL
-    response = EventInfo.model_validate(event)
-    response.image_url = get_image_url(request, media_uuid)
-    
-    return response
-
-@router.delete("/event/image", response_model=EventInfo, summary="Delete event image")
-async def delete_event_image(
-    request: Request,
-    db: Session = Depends(get_db),
-    user_info: dict = Depends(check_role(["admin", "events_manager"]))
-):
-    """
-    Delete the event image.
-    """
-    # Get the current event
-    event = db.query(EventInfoModel).first()
-    if not event or not event.image_id:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No event image found."
-        )
-    
-    # Remove the media file
-    MediaService.remove(db, event.image_id, user_info)
-    
-    # Clear the image reference
-    event.image_id = None
-    db.commit()
-    db.refresh(event)
-    
-    # Return the updated event
-    response = EventInfo.model_validate(event)
-    return response
+        return EventInfo.model_validate(db_event)

--- a/routes/event_info.py
+++ b/routes/event_info.py
@@ -54,7 +54,7 @@ async def create_or_update_event(
         # Register media for image
         media = MediaService.register(
             db=db,
-            max_size=10 * 1024 * 1024,  # 10MB
+            max_size=50 * 1024 * 1024,  # 50MB
             allows_rewrite=True,
             valid_extensions=['.jpg', '.jpeg', '.png', '.gif', '.webp'],
             alias="event_image"

--- a/routes/ui/page.py
+++ b/routes/ui/page.py
@@ -18,7 +18,12 @@ async def create_page(page: page_schema.PageSchema, user_info: dict = Depends(ch
         {**c.dict(), "component_id": str(ObjectId())} for c in page.components
     ]
     page_id = await page_service.create_page(page.title, components_with_id)
-    return {"page_id": page_id, "title": page.title, "components": components_with_id}
+    return {"page_id": page_id,
+            "title": page.title,
+            "description": page.description,
+            "enabled": page.enabled,
+            "components": components_with_id
+    }
 
 
 @router.put("/{page_id}", response_model=page_schema.PageResponse, summary="Update an existing page")
@@ -28,7 +33,12 @@ async def update_page(page_id: str, page: page_schema.PageSchema, user_info: dic
     if not updated:
         logger.error("Failed to update page")
         raise HTTPException(status_code=404, detail="Error updating page")
-    return {"page_id": page_id, "title": page.title, "components": page.components}
+    return {"page_id": page_id,
+            "title": page.title,
+            "description": page.description,
+            "enabled": page.enabled,
+            "components": page.components
+    }
 
 
 @router.delete("/{page_id}", response_model=page_schema.DeletePageResponse, summary="Delete a page by its ID")
@@ -50,6 +60,8 @@ async def list_pages():
         {
             "page_id": page["id"],
             "title": page["title"],
+            "description": page["description"],
+            "enabled": page["enabled"],
             "components": page["components"]
         }
         for page in pages
@@ -66,6 +78,8 @@ async def get_page(page_id: str):
     return {
         "page_id": page["id"],
         "title": page["title"],
+        "description": page["description"],
+        "enabled": page["enabled"],
         "components": page["components"]
     }
 

--- a/schemas/event_info.py
+++ b/schemas/event_info.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
+
+class EventInfoBase(BaseModel):
+    """
+    Base schema for event information
+    """
+    name: str
+    description: str
+    start_time: datetime
+    end_time: datetime
+    location: str
+    image_id: Optional[str] = None
+
+class EventInfoCreate(EventInfoBase):
+    """
+    Schema for creating new event information
+    """
+    pass
+
+class EventInfo(EventInfoBase):
+    """
+    Schema for event information response
+    """
+    id: int
+    image_url: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+        arbitrary_types_allowed = True

--- a/schemas/event_info.py
+++ b/schemas/event_info.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Optional
 from pydantic import BaseModel, Field
 
+
 class EventInfoBase(BaseModel):
     """
     Base schema for event information
@@ -11,7 +12,7 @@ class EventInfoBase(BaseModel):
     start_time: datetime
     end_time: datetime
     location: str
-    image_id: Optional[str] = None
+
 
 class EventInfoCreate(EventInfoBase):
     """
@@ -19,24 +20,14 @@ class EventInfoCreate(EventInfoBase):
     """
     pass
 
+
 class EventInfo(EventInfoBase):
     """
     Schema for event information response
     """
     id: int
-    image_url: Optional[str] = None
+    image_id: Optional[str] = None
 
     class Config:
         from_attributes = True
         arbitrary_types_allowed = True
-
-class ImageUploadParams(BaseModel):
-    """Parameters for image upload"""
-    max_size: int = Field(
-        default=10 * 1024 * 1024,  # 10MB
-        description="Maximum file size in bytes"
-    )
-    allowed_extensions: list[str] = Field(
-        default=['.jpg', '.jpeg', '.png', '.gif', '.webp'],
-        description="List of allowed file extensions"
-    )

--- a/schemas/event_info.py
+++ b/schemas/event_info.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 class EventInfoBase(BaseModel):
     """
@@ -29,3 +29,14 @@ class EventInfo(EventInfoBase):
     class Config:
         from_attributes = True
         arbitrary_types_allowed = True
+
+class ImageUploadParams(BaseModel):
+    """Parameters for image upload"""
+    max_size: int = Field(
+        default=10 * 1024 * 1024,  # 10MB
+        description="Maximum file size in bytes"
+    )
+    allowed_extensions: list[str] = Field(
+        default=['.jpg', '.jpeg', '.png', '.gif', '.webp'],
+        description="List of allowed file extensions"
+    )

--- a/schemas/ui/page.py
+++ b/schemas/ui/page.py
@@ -23,6 +23,8 @@ class AddBaseComponentSchema(BaseModel):
 
 class PageSchema(BaseModel):
     title: str = Field(..., title="Page Title")
+    description: Optional[str] = Field(default=None, title="Page Description")
+    enabled: bool = Field(default=True, title="Is Page Enabled")
     components: List[AddBaseComponentSchema] = Field(default_factory=list)
 
     class Config:
@@ -36,6 +38,8 @@ class Page(BaseModel):
     page_id: Optional[str] = Field(
         default_factory=lambda: str(ObjectId()), title="Page ID")
     title: str = Field(..., title="Page Title")
+    description: Optional[str] = Field(default=None, title="Page Description")
+    enabled: bool = Field(default=True, title="Is Page Enabled")
     components: List[Dict[str, Any]] = Field(default_factory=list)
 
     class Config:
@@ -46,6 +50,8 @@ class Page(BaseModel):
 class PageResponse(BaseModel):
     page_id: str
     title: str
+    description: Optional[str]
+    enabled: bool
     components: List[BaseComponentSchema]
 
     class Config:


### PR DESCRIPTION
This pull request introduces several significant changes across multiple files, mainly focusing on adding event information management, enhancing page descriptions and states, and defining media service error messages. Below is a summary of the most important changes:

### Event Information Management:

* **New Event Model and Schema:**
  - Added `Event` model to store event details, including name, description, start and end times, location, and image reference (`models/event_info.py`).
  - Introduced `EventInfoBase`, `EventInfoCreate`, and `EventInfo` schemas to handle event data (`schemas/event_info.py`).

* **Event Info API Endpoints:**
  - Created new API routes to manage event information, including creating, updating, retrieving, and deleting events and their images (`routes/event_info.py`).
  - Included the new `event_info` router in the main application routes (`routes/__init__.py`).

### Page Enhancements:

* **Page Schema and API Updates:**
  - Updated `PageSchema` and `PageResponse` to include `description` and `enabled` fields (`schemas/ui/page.py`). [[1]](diffhunk://#diff-c596b2a9b869d79e9aac554a88b5be79cbb6ac21c646d1b7f2ecad19625aaec2R26-R27) [[2]](diffhunk://#diff-c596b2a9b869d79e9aac554a88b5be79cbb6ac21c646d1b7f2ecad19625aaec2R41-R42) [[3]](diffhunk://#diff-c596b2a9b869d79e9aac554a88b5be79cbb6ac21c646d1b7f2ecad19625aaec2R53-R54)
  - Modified `create_page`, `update_page`, `list_pages`, and `get_page` functions to handle the new fields (`routes/ui/page.py`). [[1]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L21-R26) [[2]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L31-R41) [[3]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194R63-R64) [[4]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194R81-R82)

* **Default Pages Descriptions:**
  - Added `description` and `enabled` fields to default pages created in `create_default_pages` function (`defaults.py`). [[1]](diffhunk://#diff-37246ee245a95416d0eb00117b678af98285b36eba3ffdeba49222317c1d0881R76-R77) [[2]](diffhunk://#diff-37246ee245a95416d0eb00117b678af98285b36eba3ffdeba49222317c1d0881R90-R91) [[3]](diffhunk://#diff-37246ee245a95416d0eb00117b678af98285b36eba3ffdeba49222317c1d0881R127-R128)

### Media Service Error Messages:

* **New Media Error Constants:**
  - Defined a set of error messages for media operations, such as not found, already exists, invalid extension, and file too large (`constants/errors.py`).