### PR TITLE
Fix when creating activity default page.

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -112,7 +112,7 @@ async def create_default_pages():
 
         text_component = Text(
             name="Text",
-            content="This is a page for activities. skfl df jf kdf ddfh d jkfsj fdshf dj fds jdfh kjfhdsjkhf sh fjds jkh hjk dj dkj sjkf jskd dh fdsjk fkjsh sdh sjk kfsj hkjsdh fkshh fds fhdfsjfkfdhf fsdjhf sjhf dj ksdhsjd kjh fdfhkjjhfdskjf d jfdsjf dsjf jfkkdh sjfh jhf shhf jsh jsf hsjfh jkd jh jshh kjdshjsh fkshf sjkd fkshh jdh fks sj skh fjs sh jks ksdh fjksd jshh fkjhf sjdh shf js kj dhs fkjf hf sdkj kjs dfh"
+            text="This is a page for activities. skfl df jf kdf ddfh d jkfsj fdshf dj fds jdfh kjfhdsjkhf sh fjds jkh hjk dj dkj sjkf jskd dh fdsjk fkjsh sdh sjk kfsj hkjsdh fkshh fds fhdfsjfkfdhf fsdjhf sjhf dj ksdhsjd kjh fdfhkjjhfdskjf d jfdsjf dsjf jfkkdh sjfh jhf shhf jsh jsf hsjfh jkd jh jshh kjdshjsh fkshf sjkd fkshh jdh fks sj skh fjs sh jks ksdh fjksd jshh fkjhf sjdh shf js kj dhs fkjf hf sdkj kjs dfh"
         )
 
         button_component = Button(


### PR DESCRIPTION
This pull request includes a small change to the `defaults.py` file. The change modifies the `Text` component in the `create_default_pages` function to use the `text` attribute instead of the `content` attribute. This would cause an error creating this default page.

* [`defaults.py`](diffhunk://#diff-37246ee245a95416d0eb00117b678af98285b36eba3ffdeba49222317c1d0881L115-R115): Changed the `Text` component's attribute from `content` to `text` in the `create_default_pages` function.