### PR TITLE
Require AUth added

### DIFF
--- a/schemas/ui/page.py
+++ b/schemas/ui/page.py
@@ -7,6 +7,10 @@ class BaseComponentSchema(BaseModel):
     name: str = Field(..., title="Component Name")
     component_id: Optional[str] = Field(
         default_factory=lambda: str(ObjectId()), title="Component ID")
+    require_auth: bool = Field(
+        default=False, title="Requires Authentication",
+        description="Whether the component should require user authentication"
+    )
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
This pull request includes a change to the `schemas/ui/page.py` file, specifically to the `BaseComponentSchema` class. The change adds a new field to indicate whether the component should require user authentication.

* [`schemas/ui/page.py`](diffhunk://#diff-c596b2a9b869d79e9aac554a88b5be79cbb6ac21c646d1b7f2ecad19625aaec2R10-R13): Added a `require_auth` field to the `BaseComponentSchema` class to specify if the component requires user authentication.