### PR TITLE
Media Service Comments

### DIFF
--- a/services/media.py
+++ b/services/media.py
@@ -87,8 +87,8 @@ class MediaService:
         alias: Optional[str] = None
     ) -> Media:
         """
-        [INTERNAL USE ONLY]
-        Register a new media entity. This method should only be called by internal services.
+        Not called by any endpoint. Should be called where needed.
+        Register a new media entity, i.e, only the metadata not the file itself.
 
         Args:
             db: Database session
@@ -116,7 +116,7 @@ class MediaService:
     @classmethod
     def create(cls, db: Session, uuid: str, data: BinaryIO, filename: str, user: Optional[dict] = None) -> Media:
         """
-        Create new media file
+        Create the new media file itself and save it to the repository.
 
         Args:
             db: Database session
@@ -204,7 +204,8 @@ class MediaService:
     @classmethod
     def create_or_replace(cls, db: Session, uuid: str, data: BinaryIO, filename: str, user: Optional[dict] = None) -> Media:
         """
-        Create or replace media file
+        Create or replace the media file itself and save it to the repository.
+        Similar to create, but allows replacing existing files.
 
         Args:
             db: Database session
@@ -279,7 +280,8 @@ class MediaService:
     @classmethod
     def remove(cls, db: Session, uuid: str, user: Optional[dict] = None) -> None:
         """
-        Remove media file
+        Remove the media file itself from the repository.
+        This does not delete the media entity from the database.
 
         Args:
             db: Database session
@@ -314,8 +316,8 @@ class MediaService:
     @classmethod
     def unregister(cls, db: Session, uuid: str, force: bool = False) -> None:
         """
-        [INTERNAL USE ONLY]
-        Unregister media entity. This method should only be called by internal services.
+        Also not available in an endpoint. Should be called where needed.
+        Unregister a media entity from the database and its file if it exists, i.e., delete the metadata and the file itself.
 
         Args:
             db: Database session

--- a/services/media.py
+++ b/services/media.py
@@ -88,7 +88,7 @@ class MediaService:
     ) -> Media:
         """
         Not called by any endpoint. Should be called where needed.
-        Register a new media entity, i.e, only the metadata not the file itself.
+        Register a new media entity, i.e., only the metadata, not the file itself.
 
         Args:
             db: Database session


### PR DESCRIPTION
This pull request includes updates to the `services/media.py` file, focusing on clarifying the purpose and usage of several methods related to media file management. The changes primarily involve updating the docstrings for better understanding.

Clarifications in method docstrings:

* [`services/media.py`](diffhunk://#diff-3072ae0637435c18d2d33a468a5d013ef470f70f370c77e3035599eb9b4f01beL90-R91): Updated the `register` method to clarify that it registers only the metadata and is not called by any endpoint.
* [`services/media.py`](diffhunk://#diff-3072ae0637435c18d2d33a468a5d013ef470f70f370c77e3035599eb9b4f01beL119-R119): Updated the `create` method to specify that it creates and saves the media file itself to the repository.
* [`services/media.py`](diffhunk://#diff-3072ae0637435c18d2d33a468a5d013ef470f70f370c77e3035599eb9b4f01beL207-R208): Updated the `create_or_replace` method to indicate that it allows replacing existing files and saves them to the repository.
* [`services/media.py`](diffhunk://#diff-3072ae0637435c18d2d33a468a5d013ef470f70f370c77e3035599eb9b4f01beL282-R284): Updated the `remove` method to clarify that it removes the media file from the repository but does not delete the media entity from the database.
* [`services/media.py`](diffhunk://#diff-3072ae0637435c18d2d33a468a5d013ef470f70f370c77e3035599eb9b4f01beL317-R320): Updated the `unregister` method to note that it unregisters the media entity and deletes both the metadata and the file itself, and is not available in an endpoint.