### PR TITLE
Add to the image support to upload media

### DIFF
--- a/routes/media.py
+++ b/routes/media.py
@@ -1,15 +1,24 @@
-from fastapi import APIRouter, Depends, UploadFile, File, Response
+from fastapi import APIRouter, Depends, UploadFile, File, Response, HTTPException
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from typing import Optional
 import magic
 
 from dependencies.database import get_db
-from dependencies.auth import get_current_user
+from dependencies.auth import get_current_user, check_role
 from services.media import MediaService
 from schemas.media import MediaResponse
 
 router = APIRouter()
+
+
+@router.post("/register", response_model=MediaResponse)
+async def register_media(
+    db: Session = Depends(get_db),
+    user: Optional[dict] = Depends(check_role(['customization']))
+):
+    """Register a new media object before upload"""
+    return MediaService.register(db)
 
 
 @router.post("/{uuid}", response_model=MediaResponse)

--- a/schemas/media.py
+++ b/schemas/media.py
@@ -30,3 +30,13 @@ class MediaResponse(MediaBase):
     class Config:
         """Configure Pydantic to read data from ORM"""
         from_attributes = True
+
+
+class Media(BaseModel):
+    """
+    Schema that represents a media reference through its UUID
+    """
+    uuid: str = Field(..., description="The UUID of the media")
+
+    def __str__(self) -> str:
+        return self.uuid

--- a/schemas/ui/components/image.py
+++ b/schemas/ui/components/image.py
@@ -1,4 +1,3 @@
-from typing import Union
 from pydantic import Field
 from schemas.ui.page import BaseComponentSchema
 from schemas.media import Media
@@ -12,7 +11,7 @@ class Image(BaseComponentSchema):
         src (Union[str, Media]): The source URL of the image (can be an external URL or a Media reference)
         alt (str): Alternative text for the image
     """
-    src: Union[str, Media] = Field(
+    src: str | Media = Field(
         ..., description="The source URL of the image (can be an external URL or a Media reference)")
     alt: str = Field(..., description="Alternative text for the image")
     className: str = Field(

--- a/schemas/ui/components/image.py
+++ b/schemas/ui/components/image.py
@@ -1,5 +1,7 @@
+from typing import Union
 from pydantic import Field
 from schemas.ui.page import BaseComponentSchema
+from schemas.media import Media
 
 
 class Image(BaseComponentSchema):
@@ -7,10 +9,11 @@ class Image(BaseComponentSchema):
     Schema for Image component
 
     Attributes:
-        src (str): The source URL of the image
+        src (Union[str, Media]): The source URL of the image (can be an external URL or a Media reference)
         alt (str): Alternative text for the image
     """
-    src: str = Field(..., description="The source URL of the image")
+    src: Union[str, Media] = Field(
+        ..., description="The source URL of the image (can be an external URL or a Media reference)")
     alt: str = Field(..., description="Alternative text for the image")
     className: str = Field(
         default="",

--- a/schemas/ui/page.py
+++ b/schemas/ui/page.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Literal
 from bson import ObjectId
 
 
@@ -7,7 +7,7 @@ class BaseComponentSchema(BaseModel):
     name: str = Field(..., title="Component Name")
     component_id: Optional[str] = Field(
         default_factory=lambda: str(ObjectId()), title="Component ID")
-    require_auth: bool = Field(
+    require_auth: Literal[False] = Field(
         default=False, title="Requires Authentication",
         description="Whether the component should require user authentication"
     )


### PR DESCRIPTION
This PR adds to components, like Image, the support to upload media files on Page Editor. 
It recognizes Union[str, Media] as two available options and, in case of Media, renders a file upload input.