### PR TITLE
adding speakers working qb

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,15 +51,9 @@ async def lifespan(app: FastAPI):
 app.router.lifespan_context = lifespan
 
 # CORS configuration for development environments
-origins = [
-    "http://localhost",
-    "http://localhost:5173",
-    "http://localhost:5175"
-]
-
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=["http://localhost:5173"],  # Frontend Vite dev server
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/main.py
+++ b/main.py
@@ -51,10 +51,16 @@ async def lifespan(app: FastAPI):
 app.router.lifespan_context = lifespan
 
 # CORS configuration for development environments
+origins = [
+    "http://localhost",
+    "http://localhost:5173",
+    "http://localhost:5175"
+]
+
+# CORS configuration for development environments
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],  # Frontend Vite dev server
-    allow_credentials=True,
+    allow_origins=origins, 
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
This pull request includes a small change to the CORS configuration in the `main.py` file. The change simplifies the `allow_origins` list to include only the Vite dev server URL.

* [`main.py`](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L54-R56): Updated the `allow_origins` list in the `CORSMiddleware` configuration to include only `http://localhost:5173`.