### PR TITLE
Only enabled pages being returned and endpoint that returns all.

### DIFF
--- a/routes/ui/page.py
+++ b/routes/ui/page.py
@@ -57,7 +57,7 @@ async def delete_page(page_id: str, user_info: dict = Depends(check_role(["custo
     return {"page_id": page_id}
 
 
-@router.get("/", response_model=List[page_schema.PageResponse], summary="List all pages")
+@router.get("/", response_model=List[page_schema.PageResponse], summary="List all enabled pages")
 async def list_pages():
     logger.debug("Listing all pages")
     pages = await page_service.list_pages()
@@ -70,9 +70,23 @@ async def list_pages():
             "enabled": page["enabled"],
             "components": page["components"]
         }
-        for page in pages
+        for page in pages if page.get("enabled", False) is True
     ]
 
+@router.get("/all", response_model=List[page_schema.PageResponse], summary="List all pages (enabled and disabled)")
+async def list_all_pages():
+    logger.debug("Listing all pages (enabled and disabled)")
+    pages = await page_service.list_pages()
+    return [
+        {
+            "page_id": page["id"],
+            "title": page["title"],
+            "description": page["description"],
+            "enabled": page["enabled"],
+            "components": page["components"]
+        }
+        for page in pages
+    ]
 
 @router.get("/{page_id}", response_model=page_schema.PageResponse, summary="Get a page by its ID")
 async def get_page(page_id: str):


### PR DESCRIPTION
This pull request updates the `routes/ui/page.py` file to enhance the functionality of page listing endpoints. The changes include filtering the default page listing to show only enabled pages and introducing a new endpoint to list all pages, both enabled and disabled.

### Enhancements to page listing functionality:

* Modified the `list_pages` endpoint to filter and return only enabled pages, updating the summary to reflect this change. (`[[1]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L60-R60)`, `[[2]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L73-R89)`)
* Added a new `list_all_pages` endpoint to allow listing of all pages, regardless of their enabled status. This includes the addition of a new route and corresponding logic. (`[routes/ui/page.pyL73-R89](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L73-R89)`)