### PR TITLE
Add websocket service & setup on notifications service

### DIFF
--- a/dependencies/auth.py
+++ b/dependencies/auth.py
@@ -72,11 +72,13 @@ def get_current_user(force_auth: bool = True):
                     status_code=401, detail="Not authenticated")
 
             try:
+                # Fix for the 'options' parameter error
                 token_info = keycloak_openid.decode_token(
                     token,
                     key=keycloak_openid.public_key(),
-                    options={"verify_signature": True,
-                             "verify_aud": True, "exp": True}
+                    verify_signature=True,
+                    verify_aud=True,
+                    exp=True
                 )
                 return token_info
             except Exception as decode_error:

--- a/models/message.py
+++ b/models/message.py
@@ -1,14 +1,8 @@
 from dependencies.database import Base
-from sqlalchemy import Column, Integer, String, Boolean, Enum
+from sqlalchemy import Column, Integer, String, Boolean, DateTime
 from sqlalchemy.types import Enum as SQLAlchemyEnum
-from enum import Enum as PyEnum
-
-
-class RecipientType(PyEnum):
-    UNICAST = "UNICAST"
-    MULTICAST = "MULTICAST"
-    BROADCAST = "BROADCAST"
-
+from schemas.notification import RecipientType
+from datetime import UTC, datetime
 
 class Message(Base):
     __tablename__ = "messages"
@@ -20,3 +14,4 @@ class Message(Base):
     payload = Column(String, nullable=False)
     priority = Column(Integer, nullable=False)
     delivered = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=datetime.now(UTC))

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
-from . import users, activities, activity_types, auth, plugins, totp, notifications, media, event_info
+# All routers should be imported here, otherwise they will not be included in the API
+from . import users, activities, activity_types, auth, plugins, totp, notifications, media, event_info, websocket
 from .ui import color_themes, page, main_menu, plugin_settings
 from .components import router as components_router
 

--- a/routes/notifications.py
+++ b/routes/notifications.py
@@ -1,12 +1,102 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, WebSocket
 from dependencies.auth import get_current_user
 from sqlalchemy.orm import Session
 from dependencies.database import get_db
 from services.notifications import NotificationService
+from services.websocket_service import WebSocketService, WebSocketConnection
 from schemas.notification import NotificationResponse
 from typing import List
+import logging
 
+logger = logging.getLogger("coffeebreak.notifications")
 router = APIRouter()
+
+# Initialize WebSocket handlers
+websocket_service = WebSocketService()
+notification_service = NotificationService()
+
+@websocket_service.on_receive("notifications")
+async def handle_notification_message(connection: WebSocketConnection, message: dict):
+    logger.debug(f"Received notification message: {message}")
+    try:
+        notification_service = NotificationService(None)  # DB will be set in the service
+        action = message.get("action")
+        
+        if action == "get_public_announcements":
+            # Public announcements don't require authentication
+            notifications = await notification_service.get_broadcast_notifications()
+            await connection.send({
+                "type": "notification_update",
+                "status": "success",
+                "action": "public_announcements",
+                "notifications": [n.to_dict() for n in notifications]
+            })
+            return
+
+        # All other actions require authentication
+        if not connection.is_authenticated():
+            await connection.send({
+                "type": "notification_update",
+                "status": "error",
+                "message": "Authentication required for this action"
+            })
+            return
+
+        if action == "mark_read":
+            # Mark notifications as read
+            notification_ids = message.get("notification_ids", [])
+            await notification_service.mark_notifications_read(connection.user_id, notification_ids)
+            
+            # Send confirmation back to the client
+            await connection.send({
+                "type": "notification_update",
+                "status": "success",
+                "action": "mark_read",
+                "notification_ids": notification_ids
+            })
+        
+        elif action == "get_unread":
+            # Get unread notifications
+            notifications = await notification_service.get_user_notifications(connection.user_id)
+            
+            # Send notifications to the client
+            await connection.send({
+                "type": "notification_update",
+                "status": "success",
+                "action": "unread_notifications",
+                "notifications": [n.to_dict() for n in notifications]
+            })
+        
+        else:
+            logger.warning(f"Unknown notification action: {action}")
+            await connection.send({
+                "type": "notification_update",
+                "status": "error",
+                "message": "Unknown action"
+            })
+            
+    except Exception as e:
+        logger.error(f"Error handling notification message: {str(e)}")
+        await connection.send({
+            "type": "notification_update",
+            "status": "error",
+            "message": "Internal server error"
+        })
+
+@websocket_service.on_subscribe("notifications")
+async def handle_notification_subscription(connection: WebSocketConnection):
+    """Handle new subscription to notifications topic"""
+    logger.debug(f"New subscription to notifications topic from connection {connection.connection_id}")
+    
+    # Add connection to NotificationService
+    notification_service.add_connection(connection)
+
+@websocket_service.on_unsubscribe("notifications")
+async def handle_notification_unsubscribe(connection: WebSocketConnection):
+    """Handle unsubscription from notifications topic"""
+    logger.debug(f"Unsubscribed from notifications topic: {connection.connection_id}")
+    # Remove connection from NotificationService
+    notification_service.remove_connection(connection)
 
 
 @router.get("/in-app", response_model=List[NotificationResponse])

--- a/routes/websocket.py
+++ b/routes/websocket.py
@@ -165,7 +165,6 @@ async def websocket_endpoint(websocket: WebSocket):
 
                         # Handle message with registered topic handlers
                         await websocket_service.handle_topic_message(
-                            websocket,
                             connection_id,
                             topic,
                             message["data"]

--- a/routes/websocket.py
+++ b/routes/websocket.py
@@ -1,0 +1,184 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from typing import Optional
+from services.websocket_service import WebSocketService
+from dependencies.auth import get_current_user
+import uuid
+import logging
+import json
+import asyncio
+from fastapi.middleware.cors import CORSMiddleware
+from dependencies.app import get_current_app
+
+logger = logging.getLogger("coffeebreak.websocket")
+
+# Configure CORS for WebSocket
+app = get_current_app()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # In production, replace with your frontend URL
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+async def send_subscription_confirmation(websocket: WebSocket, topic: str, status: str, message: str = None):
+    """Helper function to send subscription confirmation"""
+    response = {
+        "type": "subscription_result",
+        "status": status,
+        "topic": topic
+    }
+    if message:
+        response["message"] = message
+    
+    try:
+        await websocket.send_json(response)
+        logger.debug(f"Sent subscription confirmation for topic {topic}: {status}")
+    except Exception as e:
+        logger.error(f"Failed to send subscription confirmation: {str(e)}")
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    """
+    WebSocket endpoint for real-time communication
+    Supports both authenticated and unauthenticated connections
+    """
+    logger.info("Received WebSocket connection request")
+    try:
+        websocket_service = WebSocketService()
+        # Generate unique connection ID for this connection
+        connection_id = str(uuid.uuid4())
+        
+        try:
+            # Connect without authentication
+            await websocket_service.connect(websocket, connection_id)
+            logger.info("New WebSocket connection accepted")
+            
+            while True:
+                # Wait for messages from the client
+                try:
+                    message = await websocket.receive_json()
+                    logger.debug(f"Received message: {message}")
+                    message_type = message.get("type", "")
+                    logger.debug(f"Received message type: {message_type}")
+
+                    # Handle PING/PONG messages immediately
+                    if message_type == "ping":
+                        logger.debug(f"Received PING from {connection_id}, sending PONG")
+                        await websocket.send_json({"type": "pong"})
+                        # Update activity and continue to next message
+                        await websocket_service.update_activity(connection_id)
+                        continue
+                    elif message_type == "pong":
+                        # Just update activity and continue
+                        await websocket_service.update_activity(connection_id)
+                        continue
+
+                    # Update last activity timestamp for any other message
+                    await websocket_service.update_activity(connection_id)
+
+                    # Handle authentication message
+                    if message_type == "authenticate":
+                        try:
+                            # Set a timeout for authentication
+                            user = await asyncio.wait_for(
+                                get_current_user(message["token"]),
+                                timeout=10.0
+                            )
+                            
+                            if user:
+                                # Associate user_id with the connection
+                                await websocket_service.authenticate(connection_id, user.id)
+                                
+                                # Send authentication success message
+                                await websocket.send_json({
+                                    "type": "authentication_result",
+                                    "status": "success",
+                                    "user_id": user.id
+                                })
+                            else:
+                                await websocket.send_json({
+                                    "type": "authentication_result",
+                                    "status": "error",
+                                    "message": "Invalid authentication token"
+                                })
+                        except (asyncio.TimeoutError) as e:
+                            logger.debug("Authentication timeout")
+                            await websocket.send_json({
+                                "type": "authentication_result",
+                                "status": "error",
+                                "message": "Authentication failed"
+                            })
+
+                    # Handle subscription messages
+                    elif message_type == "subscribe" and "topic" in message:
+                        topic = message["topic"]
+                        
+                        try:
+                            # Attempt to subscribe
+                            await websocket_service.subscribe(connection_id, topic)
+                            
+                            # Send success confirmation
+                            await send_subscription_confirmation(websocket, topic, "success")
+                            logger.info(f"Successfully subscribed to topic {topic}")
+
+                        except Exception as e:
+                            logger.error(f"Failed to subscribe to topic {topic}: {str(e)}")
+                            await send_subscription_confirmation(
+                                websocket, 
+                                topic, 
+                                "error", 
+                                f"Failed to subscribe: {str(e)}"
+                            )
+
+                    # Handle unsubscribe messages
+                    elif message_type == "unsubscribe" and "topic" in message:
+                        topic = message["topic"]
+                        try:
+                            await websocket_service.unsubscribe(connection_id, topic)
+                            await websocket.send_json({
+                                "type": "unsubscription_result",
+                                "status": "success",
+                                "topic": topic
+                            })
+                            logger.info(f"Successfully unsubscribed from topic {topic}")
+                        except Exception as e:
+                            logger.error(f"Failed to unsubscribe from topic {topic}: {str(e)}")
+                            await websocket.send_json({
+                                "type": "unsubscription_result",
+                                "status": "error",
+                                "topic": topic,
+                                "message": f"Failed to unsubscribe: {str(e)}"
+                            })
+
+                    # Handle topic-specific messages
+                    elif message_type == "message" and "topic" in message and "data" in message:
+                        topic = message["topic"]
+                        # Check if user is subscribed to the topic
+                        if topic not in websocket_service.subscriptions.get(connection_id, set()):
+                            await websocket.send_json({
+                                "type": "message_result",
+                                "status": "error",
+                                "message": "Not subscribed to this topic"
+                            })
+                            continue
+
+                        # Handle message with registered topic handlers
+                        await websocket_service.handle_topic_message(
+                            websocket,
+                            connection_id,
+                            topic,
+                            message["data"]
+                        )
+
+                except json.JSONDecodeError:
+                    logger.warning(f"Received invalid JSON from {connection_id}")
+                    continue
+
+        except WebSocketDisconnect:
+            logger.info(f"WebSocket disconnected (connection_id: {connection_id})")
+            await websocket_service.disconnect(connection_id)
+
+    except Exception as e:
+        logger.error(f"WebSocket error: {str(e)}")
+        await websocket.close(code=1011)  # Internal error

--- a/services/handlers.py
+++ b/services/handlers.py
@@ -1,0 +1,18 @@
+from .message_bus import MessageBus
+from .notifications import NotificationService
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def register_notification_handlers(message_bus: MessageBus, notification_service: NotificationService):
+    """
+    Register all notification handlers with the message bus
+    """
+    # Register handler for in-app notifications
+    await message_bus.register_message_handler(
+        "in-app",
+        notification_service.handle_real_time_notification
+    )
+
+    logger.info("Registered notification handlers")

--- a/services/notifications.py
+++ b/services/notifications.py
@@ -1,7 +1,12 @@
 from sqlalchemy.orm import Session
 from models.message import Message, RecipientType
+from schemas.notification import NotificationRequest
 from services.groups import get_user_groups
-from typing import List
+from services.websocket_service import WebSocketService, WebSocketConnection
+from typing import List, Dict, Set
+import logging
+
+logger = logging.getLogger("coffeebreak.notifications")
 
 
 class NotificationService:
@@ -16,9 +21,101 @@ class NotificationService:
     def __init__(self, db: Session = None):
         if not self._initialized:
             self.db = db
+            # Store connections by user_id for authenticated users
+            self.user_connections: Dict[str, Set[WebSocketConnection]] = {}
+            # Store anonymous connections for broadcast messages
+            self.anonymous_connections: Set[WebSocketConnection] = set()
             self._initialized = True
         elif db is not None:
             self.db = db
+
+    def add_connection(self, connection: WebSocketConnection) -> None:
+        """Add a WebSocket connection to the appropriate collection"""
+        if connection.is_authenticated():
+            if connection.user_id not in self.user_connections:
+                self.user_connections[connection.user_id] = set()
+            self.user_connections[connection.user_id].add(connection)
+            logger.debug(f"Added authenticated connection for user {connection.user_id}")
+        else:
+            self.anonymous_connections.add(connection)
+            logger.debug("Added anonymous connection")
+
+    def remove_connection(self, connection: WebSocketConnection) -> None:
+        """Remove a WebSocket connection from the appropriate collection"""
+        if connection.is_authenticated():
+            if connection.user_id in self.user_connections:
+                self.user_connections[connection.user_id].discard(connection)
+                if not self.user_connections[connection.user_id]:
+                    del self.user_connections[connection.user_id]
+                logger.debug(f"Removed authenticated connection for user {connection.user_id}")
+        else:
+            self.anonymous_connections.discard(connection)
+            logger.debug("Removed anonymous connection")
+
+    async def mark_notifications_read(self, user_id: str, notification_ids: List[str]):
+        """Mark specified notifications as read"""
+        if self.db is None:
+            raise ValueError("NotificationService not initialized with a database session")
+
+        self.db.query(Message).filter(
+            Message.id.in_(notification_ids),
+            Message.recipient == user_id
+        ).update({Message.read: True})
+        
+        self.db.commit()
+
+    async def handle_real_time_notification(self, notification: NotificationRequest):
+        """
+        Handle real-time notifications and send them directly to connected clients
+        """
+        try:
+            # Handle different recipient types
+            if notification.recipient_type == RecipientType.UNICAST:
+                # Send to specific user's connections
+                if notification.recipient in self.user_connections:
+                    for connection in self.user_connections[notification.recipient]:
+                        try:
+                            await connection.send("notifications", notification)
+                        except Exception as e:
+                            logger.error(f"Error sending notification to user {notification.recipient}: {str(e)}")
+                            self.remove_connection(connection)
+
+            elif notification.recipient_type == RecipientType.MULTICAST:
+                # Get users in the group and send to their connections
+                group_id = notification.recipient
+                for user_id, connections in self.user_connections.items():
+                    user_groups = await get_user_groups(user_id)
+                    if any(group["id"] == group_id for group in user_groups):
+                        for connection in connections:
+                            try:
+                                await connection.send("notifications", notification)
+                            except Exception as e:
+                                logger.error(f"Error sending group notification to user {user_id}: {str(e)}")
+                                self.remove_connection(connection)
+
+            elif notification.recipient_type == RecipientType.BROADCAST:
+                # Send to all connections (authenticated and anonymous)
+                # First, send to all authenticated users
+                for connections in self.user_connections.values():
+                    for connection in connections:
+                        try:
+                            await connection.send("notifications", notification)
+                        except Exception as e:
+                            logger.error(f"Error sending broadcast to authenticated user: {str(e)}")
+                            self.remove_connection(connection)
+
+                # Then send to anonymous connections
+                for connection in self.anonymous_connections:
+                    try:
+                        await connection.send("notifications", notification)
+                    except Exception as e:
+                        logger.error(f"Error sending broadcast to anonymous connection: {str(e)}")
+                        self.remove_connection(connection)
+
+            logger.info(f"Real-time notification sent: {notification}")
+            logger.debug(f"Anonymous connections: {str(self.anonymous_connections)}")
+        except Exception as e:
+            logger.error(f"Error handling real-time notification: {str(e)}")
 
     async def get_user_notifications(self, user_id: str) -> List[Message]:
         """
@@ -43,7 +140,7 @@ class NotificationService:
                 (Message.recipient_type == RecipientType.MULTICAST) & (Message.recipient.in_(group_ids)) |
                 (Message.recipient_type == RecipientType.BROADCAST)
             )
-        ).all()
+        ).order_by(Message.created_at.desc()).all()
 
         # Mark notifications as delivered
         for notification in notifications:
@@ -66,6 +163,6 @@ class NotificationService:
             Message.type == "in-app",
             Message.delivered == False,
             Message.recipient_type == RecipientType.BROADCAST
-        ).all()
+        ).order_by(Message.created_at.desc()).all()
 
         return notifications

--- a/services/websocket_service.py
+++ b/services/websocket_service.py
@@ -1,0 +1,424 @@
+from typing import Dict, Literal, Set, Optional, Any, Callable, Generic, TypeVar
+from fastapi import WebSocket, WebSocketDisconnect
+from datetime import datetime, UTC
+from pydantic import BaseModel, Field
+import logging
+import asyncio
+
+logger = logging.getLogger("coffeebreak.websocket")
+
+T = TypeVar('T')
+
+class WebSocketMessage(BaseModel, Generic[T]):
+    """Base model for all WebSocket messages"""
+    type: str = Field(..., description="Message type")
+    data: T = Field(..., description="Message payload")
+    timestamp: str = Field(default_factory=lambda: datetime.now().timestamp())
+
+class TopicMessage(WebSocketMessage[T]):
+    """Model for topic messages"""
+    type: Literal["message"] = Field(..., description="Message type")
+    topic: str = Field(..., description="Message topic")
+
+class PingMessage(BaseModel):
+    """Model for ping messages"""
+    timestamp: float = Field(default_factory=lambda: datetime.now().timestamp())
+
+class PongMessage(BaseModel):
+    """Model for pong messages"""
+    pass
+
+class SubscriptionMessage(BaseModel):
+    """Model for subscription messages"""
+    topic: str
+
+class SubscriptionResultMessage(BaseModel):
+    """Model for subscription result messages"""
+    status: str
+    topic: str
+    message: Optional[str] = None
+
+class WebSocketConnection:
+    """
+    Abstraction of a WebSocket connection with additional functionality
+    """
+    def __init__(self, websocket: WebSocket, connection_id: str, service: 'WebSocketService' = None):
+        self._websocket = websocket
+        self.connection_id = connection_id
+        self._service = service
+        self.user_id = None
+        self._subscribed_topics = set()
+    
+    async def send(self, topic: str, message: Any) -> None:
+        """Send a message through the WebSocket Service"""
+        if self._service:
+            try:
+                await self._service.send_to_connection(self.connection_id, topic, message)
+            except Exception as e:
+                logger.error(f"Error sending message: {str(e)}")
+                # Schedule disconnect for after the current iteration completes
+                asyncio.create_task(self._service.disconnect(self.connection_id))
+        else:
+            await self._websocket.send_json(message)
+
+    def authenticate(self, user_id: str) -> None:
+        """Set the user_id for this connection"""
+        self.user_id = user_id
+
+    def is_authenticated(self) -> bool:
+        """Check if the connection is authenticated"""
+        return self.user_id is not None
+
+    def add_subscription(self, topic: str) -> None:
+        """Add a topic subscription"""
+        self._subscribed_topics.add(topic)
+
+    def remove_subscription(self, topic: str) -> None:
+        """Remove a topic subscription"""
+        self._subscribed_topics.discard(topic)
+
+    def has_subscription(self, topic: str) -> bool:
+        """Check if subscribed to a topic"""
+        return topic in self._subscribed_topics
+    
+    @property
+    def subscribed_topics(self) -> Set[str]:
+        """Get the subscribed topics"""
+        return self._subscribed_topics
+    
+    async def _send(self, message: Any) -> None:
+        """Send a message through the WebSocket"""
+        await self._websocket.send_json(message)
+
+    def __str__(self):
+        return f"WebSocketConnection(connection_id={self.connection_id}, user_id={self.user_id})"
+
+
+class WebSocketService:
+    """
+    Service to manage WebSocket connections and message broadcasting
+    """
+    _instance = None
+    _initialized = False
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(WebSocketService, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if self._initialized:
+            return
+
+        # Active connections mapped by connection_id
+        self.connections: Dict[str, WebSocketConnection] = {}
+        # Topic handlers mapped by topic
+        self.topic_handlers: Dict[str, Dict[str, Set[Callable]]] = {}
+        # Last activity timestamp for each connection
+        self.last_activity: Dict[str, float] = {}
+        # Ping tasks for each connection
+        self.ping_tasks: Dict[str, asyncio.Task] = {}
+        # Idle timeout in seconds (60 seconds to match client)
+        self.idle_timeout = 60
+        # Pong timeout in seconds (15 seconds)
+        self.pong_timeout = 15
+        self._initialized = True
+
+    def on_receive(self, topic: str):
+        """
+        Decorator to register a message handler for a specific topic
+        
+        Args:
+            topic (str): The topic to handle messages for
+        
+        Usage:
+            @WebSocketService().on_receive("notifications")
+            async def handle_notification(connection: WebSocketConnection, message: dict):
+                # Handle received message
+                pass
+        """
+        def decorator(handler: Callable):
+            if topic not in self.topic_handlers:
+                self.topic_handlers[topic] = {"receive": set(), "subscribe": set(), "unsubscribe": set()}
+            self.topic_handlers[topic]["receive"].add(handler)
+            logger.info(f"Registered receive handler for topic: {topic}")
+            return handler
+        return decorator
+
+    def on_subscribe(self, topic: str):
+        """
+        Decorator to register a subscription handler for a specific topic
+        
+        Args:
+            topic (str): The topic to handle subscriptions for
+        
+        Usage:
+            @WebSocketService().on_subscribe("notifications")
+            async def handle_subscription(connection: WebSocketConnection):
+                # Handle subscription
+                pass
+        """
+        def decorator(handler: Callable):
+            if topic not in self.topic_handlers:
+                self.topic_handlers[topic] = {"receive": set(), "subscribe": set(), "unsubscribe": set()}
+            self.topic_handlers[topic]["subscribe"].add(handler)
+            logger.info(f"Registered subscribe handler for topic: {topic}")
+            return handler
+        return decorator
+
+    def on_unsubscribe(self, topic: str):
+        """
+        Decorator to register an unsubscribe handler for a specific topic
+        
+        Args:
+            topic (str): The topic to handle unsubscription for
+        
+        Usage:
+            @WebSocketService().on_unsubscribe("notifications")
+            async def handle_unsubscribe(connection: WebSocketConnection):
+                # Handle unsubscription
+                pass
+        """
+        def decorator(handler: Callable):
+            if topic not in self.topic_handlers:
+                self.topic_handlers[topic] = {"receive": set(), "subscribe": set(), "unsubscribe": set()}
+            self.topic_handlers[topic]["unsubscribe"].add(handler)
+            logger.info(f"Registered unsubscribe handler for topic: {topic}")
+            return handler
+        return decorator
+
+    async def handle_topic_message(self, connection: WebSocketConnection, topic: str, message: dict):
+        """
+        Handle a message for a specific topic by calling all registered handlers
+        """
+        logger.debug(f"Handling message for topic: {topic}")
+        if topic in self.topic_handlers:
+            for handler in self.topic_handlers[topic]["receive"]:
+                try:
+                    await handler(connection, message)
+                except Exception as e:
+                    logger.error(f"Error in topic handler for {topic}: {str(e)}")
+        else:
+            logger.warning(f"No handlers registered for topic: {topic}")
+
+    async def connect(self, websocket: WebSocket, connection_id: str):
+        """
+        Establish a WebSocket connection
+        """
+        await websocket.accept()
+
+        # Create new connection
+        connection = WebSocketConnection(websocket, connection_id, self)
+        self.connections[connection_id] = connection
+        self.last_activity[connection_id] = datetime.now().timestamp()
+
+        # Start ping monitor for this connection
+        self.ping_tasks[connection_id] = asyncio.create_task(
+            self._monitor_connection(connection_id)
+        )
+
+        logger.info(f"New WebSocket connection established (connection_id: {connection_id})")
+
+    async def authenticate(self, connection_id: str, user_id: str):
+        """
+        Associate a user_id with a connection
+        """
+        if connection_id in self.connections:
+            self.connections[connection_id].authenticate(user_id)
+            logger.info(f"Connection {connection_id} authenticated as user {user_id}")
+
+    async def disconnect(self, connection_id: str) -> None:
+        """
+        Handle WebSocket disconnection
+        """
+        if connection_id in self.connections:
+            connection = self.connections[connection_id]
+            
+            # Create a copy of subscribed topics before iteration
+            topics_to_unsubscribe = connection.subscribed_topics.copy()
+            
+            # Call unsubscribe handlers for all topics
+            for topic in topics_to_unsubscribe:
+                await self.unsubscribe(connection_id, topic)
+
+            # Cancel ping task if exists
+            if connection_id in self.ping_tasks:
+                self.ping_tasks[connection_id].cancel()
+                del self.ping_tasks[connection_id]
+
+            # Remove connection
+            del self.connections[connection_id]
+            self.last_activity.pop(connection_id, None)
+
+            logger.info(f"WebSocket connection closed (connection_id: {connection_id})")
+
+    async def _monitor_connection(self, connection_id: str):
+        """
+        Monitor connection activity and send pings when idle
+        """
+        logger.info(f"Starting connection monitor for {connection_id}")
+        try:
+            while True:
+                # Check if connection still exists
+                if connection_id not in self.connections:
+                    break
+
+                current_time = datetime.now().timestamp()
+                last_activity = self.last_activity.get(connection_id, 0)
+                idle_time = current_time - last_activity
+
+                if idle_time >= self.idle_timeout:
+                    connection = self.connections[connection_id]
+                    logger.debug(f"Connection idle for {idle_time}s, sending PING to {connection_id}")
+                    
+                    try:
+                        # Send PING with Pydantic validation
+                        ping_message = WebSocketMessage(
+                            type="ping",
+                            data=PingMessage().model_dump()
+                        )
+                        await connection._send(ping_message.model_dump())
+                        
+                        # Wait for PONG with timeout
+                        try:
+                            pong_received = False
+                            async with asyncio.timeout(self.pong_timeout):
+                                while not pong_received:
+                                    message = await connection._websocket.receive_json()
+                                    if message.get("type") == "pong":
+                                        # Validate PONG message
+                                        WebSocketMessage(
+                                            type="pong",
+                                            data=PongMessage().model_dump()
+                                        )
+                                        # Update last activity timestamp
+                                        self.last_activity[connection_id] = datetime.now().timestamp()
+                                        logger.debug(f"Received PONG from {connection_id}")
+                                        pong_received = True
+                                        break
+                                    
+                        except asyncio.TimeoutError:
+                            logger.warning(f"No PONG received from {connection_id} within {self.pong_timeout}s")
+                            await self.disconnect(connection_id)
+                            break
+
+                    except WebSocketDisconnect:
+                        logger.debug(f"WebSocket disconnected for {connection_id}")
+                        await self.disconnect(connection_id)
+                        break
+                            
+                    except Exception as e:
+                        logger.error(f"Error sending PING to {connection_id}: {str(e)}")
+                        await self.disconnect(connection_id)
+                        break
+
+                await asyncio.sleep(1)  # Check every second
+                
+        except asyncio.CancelledError:
+            logger.debug(f"Connection monitor cancelled for {connection_id}")
+        except Exception as e:
+            logger.error(f"Error in connection monitor for {connection_id}: {str(e)}")
+            await self.disconnect(connection_id)
+
+    async def update_activity(self, connection_id: str):
+        """
+        Update last activity timestamp for a connection
+        """
+        if connection_id in self.last_activity:
+            self.last_activity[connection_id] = datetime.now().timestamp()
+            logger.debug(f"Updated activity timestamp for {connection_id}")
+
+    async def subscribe(self, connection_id: str, topic: str) -> None:
+        """
+        Subscribe a connection to a topic
+        """
+        if connection_id in self.connections:
+            connection = self.connections[connection_id]
+            connection.add_subscription(topic)
+            logger.debug(f"Connection {connection_id} subscribed to topic {topic}")
+
+            # Call subscription handlers
+            if topic in self.topic_handlers:
+                for handler in self.topic_handlers[topic]["subscribe"]:
+                    try:
+                        await handler(connection)
+                    except Exception as e:
+                        logger.error(f"Error in subscription handler for {topic}: {str(e)}")
+
+    async def unsubscribe(self, connection_id: str, topic: str):
+        """
+        Unsubscribe a connection from a topic
+        """
+        if connection_id in self.connections:
+            connection = self.connections[connection_id]
+            
+            # Call unsubscribe handlers before removing the subscription
+            if topic in self.topic_handlers:
+                for handler in self.topic_handlers[topic]["unsubscribe"]:
+                    try:
+                        await handler(connection)
+                    except Exception as e:
+                        logger.error(f"Error in unsubscribe handler for {topic}: {str(e)}")
+            
+            connection.remove_subscription(topic)
+            logger.debug(f"Connection {connection_id} unsubscribed from topic {topic}")
+
+    def _prepare_message(self, topic: str, message: Any, message_type: str = "message") -> dict:
+        """
+        Prepare message for sending with standard format and validate using Pydantic
+        """
+        if isinstance(message, BaseModel):
+            message = message.model_dump()
+        
+        ws_message = TopicMessage(
+            type=message_type,
+            topic=topic,
+            data=message
+        )
+        return ws_message.model_dump()
+    
+    async def send_to_connection(self, connection_id: str, topic: str, message: Any) -> None:
+        """
+        Send a message to a specific connection
+        """
+        message_data = self._prepare_message(topic, message)
+        await self.connections[connection_id]._send(message_data)
+
+    async def broadcast_to_user(self, target_user_id: str, topic: str, message: Any) -> None:
+        """
+        Broadcast a message to all connections of a specific user (send_to_connection is preferred)
+        """
+        message_data = self._prepare_message(topic, message)
+
+        for connection in self.connections.values():
+            if connection.user_id == target_user_id:
+                try:
+                    await connection._send(message_data)
+                except Exception as e:
+                    logger.error(f"Error sending message to user {target_user_id}: {str(e)}")
+
+    async def broadcast_to_topic(self, topic: str, message: Any) -> None:
+        """
+        Broadcast a message to all connections subscribed to a topic (send_to_connection is preferred)
+        """
+        message_data = self._prepare_message(topic, message)
+
+        for connection in self.connections.values():
+            if connection.has_subscription(topic):
+                try:
+                    await connection._send(message_data)
+                except Exception as e:
+                    logger.error(f"Error broadcasting to topic {topic}: {str(e)}")
+
+    async def broadcast_to_all(self, topic: str, message: Any) -> None:
+        """
+        Broadcast a message to all connected clients (send_to_connection is preferred)
+        """
+        message_data = self._prepare_message(topic, message)
+
+        for connection in self.connections.values():
+            try:
+                await connection._send(message_data)
+            except Exception as e:
+                logger.error(f"Error broadcasting to all: {str(e)}")
+

--- a/utils/task.py
+++ b/utils/task.py
@@ -1,11 +1,28 @@
 from fastapi import BackgroundTasks
+import logging
+import asyncio
+
+logger = logging.getLogger("coffeebreak.core")
 
 class TaskService:
+    _instance = None
+    _initialized = False
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(TaskService, cls).__new__(cls)
+        return cls._instance
+    
     def __init__(self):
+        if self._initialized:
+            return
+        
         self.background_tasks = BackgroundTasks()
+        self._initialized = True
 
     def add_task(self, func, *args, **kwargs):
-        self.background_tasks.add_task(func, *args, **kwargs)
+        logger.info(f"Adding task: {func.__name__}")
+        return asyncio.create_task(func(*args, **kwargs))
 
     def get_tasks(self):
         return self.background_tasks


### PR DESCRIPTION
This PR includes, not only the WebSocket Service, but also its implementation in Notifications Service.

WebSocket Service is resposible for:
- guarantee connection activity, by using a PING mechanism
- safely remove connections that don't respond
- channel all comunications in a single WebSocket connection to evict connections count explosion
- hides internal protocol details from Service clients, like the Notifications Service or other plugins