### PR TITLE
Scrum 209 create video component

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -8,6 +8,7 @@ from schemas.ui.components.image import Image
 from schemas.ui.components.text import Text
 from schemas.ui.components.button import Button
 from schemas.ui.components.location import Location
+from schemas.ui.components.video import Video
 from services.component_registry import ComponentRegistry
 from services.media import MediaService
 from repository.media import LocalMediaRepo
@@ -71,14 +72,6 @@ async def create_default_pages():
     """Creates default pages if they don't exist"""
     pages_collection = db['pages']
     if await pages_collection.count_documents({}) == 0:
-        location_component = Location(
-            name="Location",
-            address = "Aveiro, Portugal", 
-            venueTitle = "Event Venue",
-            latitude=40.62338,
-            longitude=-8.65784,
-            zoom=15
-        )
 
         # Create home page with Welcome component
         home_page = Page(
@@ -186,6 +179,8 @@ async def register_default_components():
     logger.debug("Registered Button component")
     component_registry.register_component(Location)
     logger.debug("Registered Location component")
+    component_registry.register_component(Video)
+    logger.debug("Registered Video component")
 
 
 async def initialize_defaults():

--- a/schemas/ui/components/video.py
+++ b/schemas/ui/components/video.py
@@ -1,0 +1,24 @@
+from pydantic import Field
+from schemas.ui.page import BaseComponentSchema
+from schemas.ui.color import Color
+from schemas.media import Media
+
+class Video(BaseComponentSchema):
+    """
+    Schema for Video component
+
+    Attributes:
+        src (str): The source URL of the video
+        autoplay (bool): Whether the video should autoplay
+        controls (bool): Whether to show video controls
+        loop (bool): Whether the video should loop
+        muted (bool): Whether the video should be muted
+        poster (str): The URL of the poster image for the video
+    """
+    src: str | Media = Field(
+        ..., description="The source URL of the video (can be an external URL or a Media reference)")
+    autoplay: bool = Field(default=False, description="Whether the video should autoplay", optional=True)
+    controls: bool = Field(default=True, description="Whether to show video controls", optional=True)
+    loop: bool = Field(default=False, description="Whether the video should loop", optional=True)
+    muted: bool = Field(default=False, description="Whether the video should be muted", optional=True)
+    poster: str = Field(default=None, description="The URL of the poster image for the video", optional=True)

--- a/schemas/ui/components/video.py
+++ b/schemas/ui/components/video.py
@@ -1,7 +1,7 @@
 from pydantic import Field
 from schemas.ui.page import BaseComponentSchema
-from schemas.ui.color import Color
 from schemas.media import Media
+from typing import Optional
 
 class Video(BaseComponentSchema):
     """
@@ -14,11 +14,36 @@ class Video(BaseComponentSchema):
         loop (bool): Whether the video should loop
         muted (bool): Whether the video should be muted
         poster (str): The URL of the poster image for the video
+        title (str): The title of the video
+        description (str): A description of the video content
+        allowFullscreen (bool): Whether to allow fullscreen mode
+        startAt (int): Time in seconds to start the video at
     """
+    title: str = Field(
+        default="",
+        description="The title of the video",
+        optional=True
+    )
+    description: str = Field(
+        default="",
+        description="A description of the video content",
+        optional=True
+    )
     src: str | Media = Field(
         ..., description="The source URL of the video (can be an external URL or a Media reference)")
     autoplay: bool = Field(default=False, description="Whether the video should autoplay", optional=True)
     controls: bool = Field(default=True, description="Whether to show video controls", optional=True)
     loop: bool = Field(default=False, description="Whether the video should loop", optional=True)
     muted: bool = Field(default=False, description="Whether the video should be muted", optional=True)
-    poster: str = Field(default=None, description="The URL of the poster image for the video", optional=True)
+    allowFullscreen: bool = Field(default=True, description="Whether to allow fullscreen mode", optional=True)
+    startAt: int = Field(
+        default=0,
+        description="Time in seconds to start the video at",
+        optional=True,
+        ge=0
+    )
+    poster: Optional[str | Media] = Field(
+        default=None,
+        description="The URL of the poster image for the video (can be an external URL or a Media reference)",
+        optional=True
+    )


### PR DESCRIPTION
This pull request introduces a new `Video` component to the project, including its schema definition, registration in the component registry, and integration into the default setup process. Additionally, it removes the `Location` component from the default pages setup.

### New `Video` Component Integration:

* Added a `Video` component schema in `schemas/ui/components/video.py`, defining attributes such as `src`, `autoplay`, `controls`, `loop`, `muted`, `poster`, and more. This schema supports both external URLs and media references.
* Registered the `Video` component in the `ComponentRegistry` within the `register_default_components` function in `defaults.py`.
* Imported the `Video` component in `defaults.py` to make it available for use.

### Changes to Default Pages Setup:

* Removed the `Location` component from the default pages creation process in the `create_default_pages` function in `defaults.py`. This indicates a shift in the default setup strategy.