### PR TITLE
add config_page attribute

### DIFF
--- a/schemas/plugin.py
+++ b/schemas/plugin.py
@@ -13,3 +13,4 @@ class PluginDetails(BaseModel):
     has_router: bool
     is_loaded: bool
     description: str
+    config_page: bool

--- a/services/plugin_service.py
+++ b/services/plugin_service.py
@@ -27,7 +27,8 @@ def get_plugin_details(plugin_name: str) -> PluginDetails:
         has_unregister=hasattr(module, 'UNREGISTER'),
         has_router=hasattr(module, 'router'),
         is_loaded=is_plugin_loaded(plugin_name),
-        description=getattr(module, 'DESCRIPTION', "No description provided")
+        description=getattr(module, 'DESCRIPTION', "No description provided"),
+        config_page=getattr(module, 'CONFIG_PAGE', False),
     )
 
 def get_all_plugin_details() -> list[PluginDetails]:


### PR DESCRIPTION
This pull request introduces a new `config_page` attribute to the `PluginDetails` model and updates the service logic to populate this attribute. These changes enhance the plugin system by allowing plugins to specify if they have a configuration page.

### Enhancements to plugin details:

* [`schemas/plugin.py`](diffhunk://#diff-9d9e7a8469eab0cd64cd9066892bfad1ed05c4308f01eac61f852c93d2c8e47aR16): Added a new `config_page` attribute of type `bool` to the `PluginDetails` model. This attribute indicates whether a plugin has a configuration page.
* [`services/plugin_service.py`](diffhunk://#diff-18726759ed8f6323b812dfeb180edbc78d562bfe6541f950e4191d37bdbd825aL30-R31): Updated the `get_plugin_details` function to retrieve the `CONFIG_PAGE` attribute from the plugin module and set it as the value for the `config_page` attribute in `PluginDetails`. Defaults to `False` if the `CONFIG_PAGE` attribute is not defined.