### PR TITLE
Error fix.

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -12,7 +12,7 @@ from schemas.ui.components.text import Text
 from schemas.ui.components.button import Button
 from schemas.ui.components.location import Location
 from schemas.ui.components.video import Video
-from core.schemas.ui.components.activities import Activities
+from schemas.ui.components.activities import Activities
 from services.component_registry import ComponentRegistry
 from services.media import MediaService
 from repository.media import LocalMediaRepo


### PR DESCRIPTION
This pull request includes a small change to the import statement in `defaults.py`. The change updates the import path for `Activities` to correctly reference `schemas.ui.components.activities` instead of `core.schemas.ui.components.activities`.