### PR TITLE
fix plugin unloading (route removal)

### DIFF
--- a/plugin_loader.py
+++ b/plugin_loader.py
@@ -170,7 +170,11 @@ def _remove_plugin_routes(app: APIRouter, module) -> None:
         return
 
     router = module.router.get_router()
-    app.routes = [route for route in app.routes if route not in router.routes]
+
+    for i, route in enumerate(app.routes):
+        if hasattr(route, 'routes') and route.routes == router.routes:
+            app.routes.pop(i)
+            break
 
 
 async def unload_plugin(app: APIRouter, plugin_name: str) -> bool:


### PR DESCRIPTION
This pull request refines the logic for removing plugin routes in the `plugin_loader.py` file. The key change replaces a list comprehension with a loop that checks for a match using `hasattr` and removes the route directly.

Code refinement:

* [`plugin_loader.py`](diffhunk://#diff-41cb25b5a9a467e6bd0ff77790abc37b3fd3b9538eb485a1fb735f4df80d4179L173-R177): Updated the `_remove_plugin_routes` function to use a loop with `hasattr` to check if a route has the `routes` attribute and matches `router.routes`. This ensures only the intended route is removed and avoids potential issues with object comparison.