### PR TITLE
remove useless pages and components

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -1,11 +1,9 @@
 import logging
-from typing import List, Annotated
 
-from pydantic import Field, BaseModel
 from dependencies.mongodb import db
 from schemas.ui.menu import Menu, MenuOption
 from schemas.ui.color_theme import ColorTheme
-from schemas.ui.page import BaseComponentSchema, Page
+from schemas.ui.page import Page
 from schemas.ui.components.title import Title
 from schemas.ui.components.image import Image
 from schemas.ui.components.text import Text
@@ -58,8 +56,6 @@ async def create_default_main_menu():
     if await main_menu_collection.count_documents({}) == 0:
         default_main_menu = Menu(options=[
             MenuOption(icon="FaHome", label="Home", href="/home"),
-            MenuOption(icon="FaUser", label="Profile", href="/profile"),
-            MenuOption(icon="FaBook", label="Activity", href="/activity"),
         ])
         await main_menu_collection.insert_one(default_main_menu.model_dump())
 
@@ -87,58 +83,6 @@ async def create_default_pages():
         )
         await pages_collection.insert_one(home_page.model_dump())
         logger.debug(f"Created default home page: {home_page}")
-
-        # Create profile page with UserProfile component
-        profile_page = Page(
-            title="Profile",
-            description="User profile page",
-            enabled=True,
-            components=[
-                {
-                    "name": "User Profile"
-                }
-            ]
-        )
-        await pages_collection.insert_one(profile_page.model_dump())
-        logger.debug(f"Created default profile page: {profile_page}")
-
-        # Create activity page with multiple components
-        title_component = Title(
-            name="Title",
-            text="Activity about AI"
-        )
-
-        image_component = Image(
-            name="Image",
-            src="",
-            alt="Activity Image"
-        )
-
-        text_component = Text(
-            name="Text",
-            text="This is a page for activities. skfl df jf kdf ddfh d jkfsj fdshf dj fds jdfh kjfhdsjkhf sh fjds jkh hjk dj dkj sjkf jskd dh fdsjk fkjsh sdh sjk kfsj hkjsdh fkshh fds fhdfsjfkfdhf fsdjhf sjhf dj ksdhsjd kjh fdfhkjjhfdskjf d jfdsjf dsjf jfkkdh sjfh jhf shhf jsh jsf hsjfh jkd jh jshh kjdshjsh fkshf sjkd fkshh jdh fks sj skh fjs sh jks ksdh fjksd jshh fkjhf sjdh shf js kj dhs fkjf hf sdkj kjs dfh"
-        )
-
-        button_component = Button(
-            name="Button",
-            text="Start Activity",
-            METHOD="GET",
-            URL="https://jsonplaceholder.typicode.com/posts/1"
-        )
-
-        activity_page = Page(
-            title="Activity",
-            description="Activity page with multiple components",
-            enabled=True,
-            components=[
-                title_component.model_dump(),
-                image_component.model_dump(),
-                text_component.model_dump(),
-                button_component.model_dump()
-            ]
-        )
-        await pages_collection.insert_one(activity_page.model_dump())
-        logger.debug(f"Created default activity page: {activity_page}")
 
 
 async def create_default_color_theme():
@@ -187,21 +131,6 @@ async def register_default_components():
     logger.debug("Registered Video component")
     component_registry.register_component(Activities)
     logger.debug("Registered Activities component")
-
-    class TestComponent(BaseComponentSchema):
-        name: str = Field(default="Test Component")
-        numeros: List[int] = Field(default=[])
-    
-    component_registry.register_component(TestComponent)
-
-    class TestComponent2(BaseComponentSchema):
-        name: str = Field(default="Test Component 2")
-        numeros: Annotated[int, Field(title="Number")] \
-            | Annotated[str, Field(title="Text")] \
-            | Annotated[bool, Field(title="Flag")] \
-            | Annotated[list[Annotated[int, Field(ge=0, le=10)]], Field(title="Number List")] = Field(default=0)
-        
-    component_registry.register_component(TestComponent2)
 
 
 async def initialize_defaults():


### PR DESCRIPTION
This pull request simplifies the `defaults.py` file by removing unused imports, redundant menu options, unnecessary default pages, and test components. The changes aim to streamline the codebase and focus on essential functionality.

### Code Simplification:

* **Removed unused imports**: Eliminated `List`, `Annotated`, `Field`, and `BaseModel` imports, as well as unused imports from `schemas.ui.page`.

* **Simplified default menu**: Removed the "Profile" and "Activity" options from the default main menu, leaving only the essential "Home" option.

* **Removed unnecessary default pages**: Deleted the creation logic for the "Profile" and "Activity" pages, including their components (e.g., `Title`, `Image`, `Text`, and `Button`).

* **Deleted test components**: Removed `TestComponent` and `TestComponent2` from the component registry, as they were likely used for testing purposes and are no longer needed.