### PR TITLE
add activity owner and fix activity

### DIFF
--- a/models/activity.py
+++ b/models/activity.py
@@ -22,10 +22,10 @@ class Activity(Base):
 
     # optional content for diferent types of activity
     topic = Column(String, nullable=True)
-    speaker = Column(String, nullable=True)
     facilitator = Column(String, nullable=True)
     type_id = Column(Integer, ForeignKey("activity_types.id"), nullable=False)
 
     type = relationship("ActivityType", back_populates="activities")
+    owners = relationship("ActivityOwner", back_populates="activity")
 
 

--- a/models/activity_owner.py
+++ b/models/activity_owner.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from dependencies.database import Base
+from sqlalchemy.orm import relationship
+
+class ActivityOwner(Base):
+    __tablename__ = "activity_owners"
+
+    id = Column(Integer, primary_key=True, index=True)
+    activity_id = Column(Integer, ForeignKey("activities.id"), nullable=False)
+    user_id = Column(String, nullable=False)
+
+    activity = relationship("Activity", back_populates="owners")

--- a/routes/activities.py
+++ b/routes/activities.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from dependencies.database import get_db
 from dependencies.auth import check_role
 from schemas.activity import Activity as ActivitySchema, ActivityCreate
+from schemas.activity_owner import ActivityOwner as ActivityOwnerSchema, ActivityOwnerCreate
 from services.activity import ActivityService
 from exceptions.activity import ActivityError
 
@@ -54,5 +55,39 @@ def delete_activity(activity_id: int, db: Session = Depends(get_db), user: dict 
 def remove_activity_image(activity_id: int, db: Session = Depends(get_db), user: dict = Depends(check_role(["manage_activities"]))):
     try:
         return ActivityService(db).remove_image(activity_id)
+    except ActivityError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+@router.post("/{activity_id}/owners", response_model=ActivityOwnerSchema)
+def add_activity_owner(
+    activity_id: int,
+    owner: ActivityOwnerCreate,
+    db: Session = Depends(get_db),
+    _: dict = Depends(check_role(["manage_activities"]))
+):
+    try:
+        return ActivityService(db).add_owner(activity_id, owner.user_id)
+    except ActivityError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+@router.delete("/{activity_id}/owners/{user_id}", response_model=ActivityOwnerSchema)
+def remove_activity_owner(
+    activity_id: int,
+    user_id: str,
+    db: Session = Depends(get_db),
+    _: dict = Depends(check_role(["manage_activities"]))
+):
+    try:
+        return ActivityService(db).remove_owner(activity_id, user_id)
+    except ActivityError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.message)
+
+@router.get("/{activity_id}/owners", response_model=List[ActivityOwnerSchema])
+def get_activity_owners(
+    activity_id: int,
+    db: Session = Depends(get_db)
+):
+    try:
+        return ActivityService(db).get_owners(activity_id)
     except ActivityError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)

--- a/schemas/activity.py
+++ b/schemas/activity.py
@@ -25,7 +25,6 @@ class ActivityBase(BaseModel):
     type_id: int
 
     topic: Optional[str] = None
-    speaker: Optional[str] = None
     facilitator: Optional[str] = None
 
     class Config:

--- a/schemas/activity_owner.py
+++ b/schemas/activity_owner.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+class ActivityOwnerBase(BaseModel):
+    activity_id: int
+    user_id: str
+
+class ActivityOwnerCreate(ActivityOwnerBase):
+    pass
+
+class ActivityOwner(ActivityOwnerBase):
+    id: int
+
+    class Config:
+        from_attributes = True 


### PR DESCRIPTION
This pull request introduces support for managing activity owners in the system. It includes schema, model, service, and route updates to enable adding, removing, and retrieving owners for activities. Additionally, the `speaker` field has been removed from the `Activity` model and related schemas.

### New functionality for managing activity owners:

* **Database Model**: Added a new `ActivityOwner` model in `models/activity_owner.py` to represent the relationship between activities and their owners. This includes fields for `activity_id` and `user_id`, along with a relationship to the `Activity` model. (`[models/activity_owner.pyR1-R12](diffhunk://#diff-fe4d486f79805a05fe19b24a2121fb0bbabf80291a97a997f712ddd39dec2921R1-R12)`)
* **API Endpoints**: Added endpoints in `routes/activities.py` to:
  - Add an owner to an activity (`POST /{activity_id}/owners`)
  - Remove an owner from an activity (`DELETE /{activity_id}/owners/{user_id}`)
  - Retrieve all owners of an activity (`GET /{activity_id}/owners`) (`[routes/activities.pyR60-R93](diffhunk://#diff-9a391a969d644ce29a87c8b6ccc7ea72b81c4fc87fe3f1d110da9c0b24bf6fddR60-R93)`)
* **Pydantic Schemas**: Introduced `ActivityOwnerBase`, `ActivityOwnerCreate`, and `ActivityOwner` schemas in `schemas/activity_owner.py` to validate and structure data for activity owners. (`[schemas/activity_owner.pyR1-R14](diffhunk://#diff-05084f6ef10c4a2c78177b9964b4a47c5d3dd832c089dd790f5c5fac309bc0bcR1-R14)`)
* **Service Layer**: Added methods in `services/activity.py` to handle the logic for adding, removing, and retrieving activity owners. These include `add_owner`, `remove_owner`, and `get_owners`. (`[services/activity.pyR237-R274](diffhunk://#diff-d1cc47c1c139965d7f7f68bd52b12c4bf13f3643b8945721cbf5036a17025751R237-R274)`)

### Other changes:

* **Field Removal**: Removed the `speaker` field from the `Activity` model and its corresponding schema (`models/activity.py`, `schemas/activity.py`). (`[[1]](diffhunk://#diff-1a9b4639ffb77fa1ded0f2c7ff553757299a459a0c29f3ea561a11b6ee5ccb75L25-R29)`, `[[2]](diffhunk://#diff-2831fcd4087e9cd977cb261bf92e6f075b12971d5a93898541ba816713382876L28)`)