### PR TITLE
Add lock for safe db tables creation

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 # All routers should be imported here, otherwise they will not be included in the API
-from . import users, activities, activity_types, auth, plugins, totp, notifications, media, event_info, websocket
+from . import users, activities, activity_types, auth, plugins, totp, notifications, media, event_info, health
 from .ui import color_themes, page, main_menu, plugin_settings
 from .components import router as components_router
 
@@ -8,6 +8,7 @@ from .components import router as components_router
 routes_app = APIRouter()
 
 # Include all routers
+routes_app.include_router(health.router, prefix="/health", tags=["Health"])
 routes_app.include_router(event_info.router,
                           prefix="/event-info", tags=["Event Information"])
 routes_app.include_router(users.router, prefix="/users", tags=["Users"])

--- a/routes/health.py
+++ b/routes/health.py
@@ -1,0 +1,7 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/")
+async def health():
+    return {"status": "ok"}


### PR DESCRIPTION
When database tables are being created and more than one worker is running, writing conflicts could happen.
To prevent this, a lock was added, making other workers to skip this step.