### PR TITLE
Default values prevent bug from happening

### DIFF
--- a/schemas/ui/components/location.py
+++ b/schemas/ui/components/location.py
@@ -12,11 +12,11 @@ class Location(BaseComponentSchema):
         zoom (int): Zoom level for the map
         className (str): CSS classes to be applied
     """
-    latitude: float = Field(..., description="Latitude of the location")
-    longitude: float = Field(..., description="Longitude of the location")
-    address: str = Field(..., description="Address of the location")
-    venueTitle: str = Field(..., description="Title of the venue")
-    zoom: int = Field(..., description="Zoom level for the map")
+    latitude: float = Field(default=40.62338, description="Latitude of the location")
+    longitude: float = Field(default=-8.65784, description="Longitude of the location")
+    address: str = Field(... , description="Address of the location")
+    venueTitle: str = Field(... , description="Title of the venue")
+    zoom: int = Field(default=12, description="Zoom level for the map")
     className: str = Field(
         default="",
         description="CSS classes to be applied",


### PR DESCRIPTION
This pull request updates the default values for several fields in the `Location` schema to provide sensible defaults for latitude, longitude, and zoom level.

### Changes to default field values:

* Updated `latitude` to have a default value of `40.62338`.
* Updated `longitude` to have a default value of `-8.65784`.
* Updated `zoom` to have a default value of `12`.