### PR TITLE
change url convention (bar at the end in collections and no bar in in…

### DIFF
--- a/routes/activities.py
+++ b/routes/activities.py
@@ -21,7 +21,7 @@ def create_activity(activity: ActivityCreate, db: Session = Depends(get_db), _: 
     except ActivityError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
 
-@router.post("/batch", response_model=List[ActivitySchema])
+@router.post("/batch/", response_model=List[ActivitySchema])
 def create_activities(activities: List[ActivityCreate], db: Session = Depends(get_db), _: dict = Depends(check_role(["manage_activities"]))):
     try:
         return ActivityService(db).create_many(activities)
@@ -58,7 +58,7 @@ def remove_activity_image(activity_id: int, db: Session = Depends(get_db), user:
     except ActivityError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
 
-@router.post("/{activity_id}/owners", response_model=ActivityOwnerSchema)
+@router.post("/{activity_id}/owners/", response_model=ActivityOwnerSchema)
 def add_activity_owner(
     activity_id: int,
     owner: ActivityOwnerCreate,
@@ -82,7 +82,7 @@ def remove_activity_owner(
     except ActivityError as e:
         raise HTTPException(status_code=e.status_code, detail=e.message)
 
-@router.get("/{activity_id}/owners", response_model=List[ActivityOwnerSchema])
+@router.get("/{activity_id}/owners/", response_model=List[ActivityOwnerSchema])
 def get_activity_owners(
     activity_id: int,
     db: Session = Depends(get_db)

--- a/routes/components.py
+++ b/routes/components.py
@@ -8,7 +8,7 @@ from schemas.components import ComponentInfo, ComponentsList
 router = APIRouter()
 
 
-@router.get("", response_model=ComponentsList)
+@router.get("/", response_model=ComponentsList)
 async def list_components():
     """
     List all registered UI components and their schemas

--- a/routes/ui/color_themes.py
+++ b/routes/ui/color_themes.py
@@ -27,7 +27,7 @@ async def update_color_theme(color_theme: ColorTheme):
     
     # Update the manifest
     manifest = await manifest_service.get_manifest()
-    manifest['theme_color'] = color_theme.primary
-    manifest['background_color'] = color_theme.base_100
+    manifest.theme_color = color_theme.primary
+    manifest.background_color = color_theme.base_100
     await manifest_service.update_manifest(manifest)
     return updated_theme

--- a/routes/ui/main_menu.py
+++ b/routes/ui/main_menu.py
@@ -18,7 +18,7 @@ async def get_main_menu():
     return main_menu
 
 
-@router.post("/option", response_model=Menu, dependencies=[Depends(check_role(["customization"]))])
+@router.post("/option/", response_model=Menu, dependencies=[Depends(check_role(["customization"]))])
 async def add_menu_option(option: MenuOptionCreate):
     return await create_menu_option(option.icon, option.label, option.href)
 
@@ -51,7 +51,7 @@ async def delete_menu_option(option_id: str):
     return await remove_menu_option(option_id)
 
 
-@router.put("/options", response_model=Menu, dependencies=[Depends(check_role(["customization"]))])
+@router.put("/options/", response_model=Menu, dependencies=[Depends(check_role(["customization"]))])
 async def update_menu_options(options: List[MenuOption]):
     main_menu = await main_menu_collection.find_one()
     if not main_menu:
@@ -62,8 +62,3 @@ async def update_menu_options(options: List[MenuOption]):
         raise HTTPException(
             status_code=500, detail="Failed to update menu options")
     return main_menu
-
-
-@router.delete("/option/by-href/{href}")
-async def delete_menu_option_by_href(href: str):
-    return await remove_menu_option_by_href(href)

--- a/routes/ui/page.py
+++ b/routes/ui/page.py
@@ -73,7 +73,7 @@ async def list_pages():
         for page in pages if page.get("enabled", False) is True
     ]
 
-@router.get("/all", response_model=List[page_schema.PageResponse], summary="List all pages (enabled and disabled)")
+@router.get("/all/", response_model=List[page_schema.PageResponse], summary="List all pages (enabled and disabled)")
 async def list_all_pages():
     logger.debug("Listing all pages (enabled and disabled)")
     pages = await page_service.list_pages()
@@ -104,7 +104,7 @@ async def get_page(page_id: str):
     }
 
 
-@router.post("/{page_id}/components", response_model=page_schema.BaseComponentSchema, summary="Add a new component to the page")
+@router.post("/{page_id}/components/", response_model=page_schema.BaseComponentSchema, summary="Add a new component to the page")
 async def add_component(page_id: str, component: page_schema.AddBaseComponentSchema, user_info: dict = Depends(check_role(["customization"]))):
     component_dict = component.dict()
     component_dict['component_id'] = str(ObjectId())

--- a/routes/users.py
+++ b/routes/users.py
@@ -55,7 +55,7 @@ async def create_user_endpoint(user_data: UserCreate):
         raise HTTPException(status_code=e.status_code, detail=str(e))
 
 
-@router.post("/batch", response_model=List[UserSchema], dependencies=[Depends(check_role(["manage_users"]))])
+@router.post("/batch/", response_model=List[UserSchema], dependencies=[Depends(check_role(["manage_users"]))])
 async def create_users_batch(users_data: List[UserCreate]):
     created_users = []
     for user_data in users_data:
@@ -67,7 +67,7 @@ async def create_users_batch(users_data: List[UserCreate]):
     return created_users
 
 
-@router.get("/roles", dependencies=[Depends(check_role(["manage_users"]))])
+@router.get("/roles/", dependencies=[Depends(check_role(["manage_users"]))])
 async def list_roles_endpoint():
     try:
         roles = await list_roles()
@@ -76,7 +76,7 @@ async def list_roles_endpoint():
         raise HTTPException(status_code=e.status_code, detail=str(e))
 
 
-@router.get("/roles/users", dependencies=[Depends(check_role(["manage_users"]))])
+@router.get("/roles/users/", dependencies=[Depends(check_role(["manage_users"]))])
 async def list_roles_endpoint():
     try:
         role_users = await list_role_users()
@@ -121,7 +121,7 @@ async def delete_user_endpoint(user_id: str):
         raise HTTPException(status_code=e.status_code, detail=str(e))
 
 
-@router.get("/permissions", response_model=Dict[str, List[str]], dependencies=[Depends(check_role(["manage_users"]))])
+@router.get("/permissions/", response_model=Dict[str, List[str]], dependencies=[Depends(check_role(["manage_users"]))])
 async def get_permissions():
     """
     Get all available permissions in the system, categorized as custom and native.


### PR DESCRIPTION
This pull request standardizes route paths across multiple files by ensuring all endpoints consistently include a trailing slash. Additionally, it refactors the `manifest` object in `routes/ui/color_themes.py` to use attribute-style access instead of dictionary-style access. Below is a summary of the most important changes grouped by theme:

### Route Path Standardization
* Added trailing slashes to all route paths in `routes/activities.py`, including `/batch/` for creating multiple activities, `/{activity_id}/owners/` for managing activity owners, and others. [[1]](diffhunk://#diff-9a391a969d644ce29a87c8b6ccc7ea72b81c4fc87fe3f1d110da9c0b24bf6fddL24-R24) [[2]](diffhunk://#diff-9a391a969d644ce29a87c8b6ccc7ea72b81c4fc87fe3f1d110da9c0b24bf6fddL61-R61) [[3]](diffhunk://#diff-9a391a969d644ce29a87c8b6ccc7ea72b81c4fc87fe3f1d110da9c0b24bf6fddL85-R85)
* Updated route paths in `routes/components.py` to include a trailing slash, such as `/` for listing components.
* Standardized route paths in `routes/ui/main_menu.py` and `routes/ui/page.py`, including `/option/` for adding menu options, `/options/` for updating menu options, and `/all/` for listing all pages. Removed an unused route for deleting menu options by href. [[1]](diffhunk://#diff-92cd30b8b5d6767e51a0cefddd9800d26ae79a4e58d9084e45a0a727bc7485ddL21-R21) [[2]](diffhunk://#diff-92cd30b8b5d6767e51a0cefddd9800d26ae79a4e58d9084e45a0a727bc7485ddL54-R54) [[3]](diffhunk://#diff-92cd30b8b5d6767e51a0cefddd9800d26ae79a4e58d9084e45a0a727bc7485ddL65-L69) [[4]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L76-R76) [[5]](diffhunk://#diff-2fe7261ac9f1709e1f12edb4c9abd6455abbbf8ca26a625b3765564abcd25194L107-R107)
* Adjusted route paths in `routes/users.py`, such as `/batch/` for batch user creation, `/roles/` for listing roles, and `/permissions/` for fetching permissions. [[1]](diffhunk://#diff-dcd08406abf41cadcb05be6040ab94a962498284bea265ac92af7c15ea1f9fb6L58-R58) [[2]](diffhunk://#diff-dcd08406abf41cadcb05be6040ab94a962498284bea265ac92af7c15ea1f9fb6L70-R70) [[3]](diffhunk://#diff-dcd08406abf41cadcb05be6040ab94a962498284bea265ac92af7c15ea1f9fb6L79-R79) [[4]](diffhunk://#diff-dcd08406abf41cadcb05be6040ab94a962498284bea265ac92af7c15ea1f9fb6L124-R124)

### Refactor for Manifest Object
* Refactored `manifest` in `routes/ui/color_themes.py` to use attribute-style access (`manifest.theme_color` and `manifest.background_color`) instead of dictionary-style access.