### PR TITLE
change defaults and simplify schemas

### DIFF
--- a/schemas/ui/components/button.py
+++ b/schemas/ui/components/button.py
@@ -32,11 +32,6 @@ class Button(BaseComponentSchema):
         default="",
         description="The URL to be called when the button is clicked"
     )
-    className: str = Field(
-        default="",
-        description="CSS classes to be applied",
-        optional=True
-    )
     backgroundColor: str = Field(
         default=Color.PRIMARY.value,
         description="Background color of the button",

--- a/schemas/ui/components/image.py
+++ b/schemas/ui/components/image.py
@@ -16,8 +16,3 @@ class Image(BaseComponentSchema):
         ..., description="The source URL of the image (can be an external URL or a Media reference)"
     )
     alt: str = Field(..., description="Alternative text for the image")
-    className: str = Field(
-        default="",
-        description="CSS classes to be applied",
-        optional=True
-    )

--- a/schemas/ui/components/location.py
+++ b/schemas/ui/components/location.py
@@ -17,8 +17,3 @@ class Location(BaseComponentSchema):
     address: str = Field(... , description="Address of the location")
     venueTitle: str = Field(... , description="Title of the venue")
     zoom: int = Field(default=12, description="Zoom level for the map")
-    className: str = Field(
-        default="",
-        description="CSS classes to be applied",
-        optional=True
-    )

--- a/schemas/ui/components/text.py
+++ b/schemas/ui/components/text.py
@@ -12,7 +12,7 @@ class Text(BaseComponentSchema):
     """
     text: str = Field(..., description="The text content to be displayed")
     color: Color = Field(
-        default=Color.PRIMARY_CONTENT,
+        default=Color.BASE_CONTENT,
         description="Text color of the text",
         enum=[color.value for color in Color],
         optional=True

--- a/schemas/ui/components/title.py
+++ b/schemas/ui/components/title.py
@@ -13,7 +13,7 @@ class Title(BaseComponentSchema):
     """
     text: str = Field(..., description="The text to be displayed")
     color: Color = Field(
-        default=Color.PRIMARY_CONTENT,
+        default=Color.BASE_CONTENT,
         description="Text color of the title",
         enum=[color.value for color in Color],
         optional=True

--- a/schemas/ui/components/video.py
+++ b/schemas/ui/components/video.py
@@ -14,21 +14,9 @@ class Video(BaseComponentSchema):
         loop (bool): Whether the video should loop
         muted (bool): Whether the video should be muted
         poster (str): The URL of the poster image for the video
-        title (str): The title of the video
-        description (str): A description of the video content
         allowFullscreen (bool): Whether to allow fullscreen mode
         startAt (int): Time in seconds to start the video at
     """
-    title: str = Field(
-        default="",
-        description="The title of the video",
-        optional=True
-    )
-    description: str = Field(
-        default="",
-        description="A description of the video content",
-        optional=True
-    )
     src: str | Media = Field(
         ..., description="The source URL of the video (can be an external URL or a Media reference)")
     autoplay: bool = Field(default=False, description="Whether the video should autoplay", optional=True)


### PR DESCRIPTION
This pull request simplifies the UI component schemas by removing unused or redundant fields and updating default values for consistency. The most important changes include the removal of the `className` field across multiple components, updates to default color values, and the removal of unused fields in the `Video` schema.

### Field Removal for Simplification:
* [`schemas/ui/components/button.py`](diffhunk://#diff-613a5b9abc0765e9a509826d079fa136f8b2a51f82ca83bb8d5f212a2cc8dfeaL35-L39): Removed the `className` field from the `Button` schema, which was used for applying CSS classes but is no longer needed.
* [`schemas/ui/components/image.py`](diffhunk://#diff-020910cfb95133aef58aef8144d7afa2b2cc268896de2b038590167550890c5cL19-L23): Removed the `className` field from the `Image` schema.
* [`schemas/ui/components/location.py`](diffhunk://#diff-ac73328e1ccc91b6f15e8a8d78a7fea32210d833e416f59cdc28e3f105304072L20-L24): Removed the `className` field from the `Location` schema.
* [`schemas/ui/components/video.py`](diffhunk://#diff-a7af89d5c545e347b59cf68aba6cf82e828def6fb4719d323c82d50cb61d8f03L17-L31): Removed the `title` and `description` fields from the `Video` schema, as they are no longer required.

### Default Value Updates:
* [`schemas/ui/components/text.py`](diffhunk://#diff-a7359619a20ca75703c3a9205893f90db6bd593734befe6cca92bba48d8ba9a1L15-R15): Updated the default color for the `Text` schema from `Color.PRIMARY_CONTENT` to `Color.BASE_CONTENT` for consistency.
* [`schemas/ui/components/title.py`](diffhunk://#diff-2ecb7abb028bd55c04f6b5425efee7b79377ef6ba5ced13a81038404e697b45eL16-R16): Updated the default color for the `Title` schema from `Color.PRIMARY_CONTENT` to `Color.BASE_CONTENT` for consistency.