### PR TITLE
Fix/update manifest name

### DIFF
--- a/routes/event_info.py
+++ b/routes/event_info.py
@@ -54,6 +54,7 @@ async def create_event(
     # Update manifest with event information
     manifest = await manifest_service.get_manifest()
     manifest.name = event.name
+    manifest.short_name = event.name
     manifest.description = event.description
     await manifest_service.update_manifest(manifest)
 
@@ -69,10 +70,10 @@ async def create_or_update_event_admin(
 ):
     existing_event = db.query(EventInfoModel).first()
 
-
     # Update manifest with event information
     manifest = await manifest_service.get_manifest()
     manifest.name = event.name
+    manifest.short_name = event.name
     manifest.description = event.description
     await manifest_service.update_manifest(manifest)
 

--- a/routes/manifest.py
+++ b/routes/manifest.py
@@ -8,7 +8,9 @@ from exceptions.manifest import ManifestNotFoundError, ManifestUpdateError, Mani
 router = APIRouter()
 manifest_service = ManifestService()
 
-@router.get("/manifest.json", response_model=Manifest)
+@router.get("/manifest.json", response_model=Manifest, 
+    summary="Get PWA manifest",
+    description="Retrieves the current PWA manifest configuration. This is used by browsers to configure the PWA installation.")
 async def get_manifest():
     try:
         manifest = await manifest_service.get_manifest()
@@ -18,7 +20,10 @@ async def get_manifest():
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.put("/manifest.json", response_model=Manifest)
+@router.put("/manifest.json", response_model=Manifest,
+    summary="Update PWA manifest",
+    description="Updates the PWA manifest configuration. Requires manage_event role.",
+    status_code=200)
 async def update_manifest(new_manifest: Manifest, _current_user: dict = Depends(check_role(["manage_event"]))):
     try:
         updated_manifest = await manifest_service.update_manifest(new_manifest)
@@ -30,7 +35,10 @@ async def update_manifest(new_manifest: Manifest, _current_user: dict = Depends(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.post("/manifest/icon", response_model=Manifest)
+@router.post("/manifest/icon", response_model=Manifest,
+    summary="Add icon to manifest",
+    description="Adds a new icon to the PWA manifest. Creates both 'any' and 'maskable' versions. Requires manage_event role.",
+    status_code=201)
 async def insert_icon(icon: InsertIcon, _current_user: dict = Depends(check_role(["manage_event"]))):
     try:
         _inserted_icon = await manifest_service.insert_icon(Icon(**icon.model_dump(), purpose="any"))


### PR DESCRIPTION
This pull request enhances the API endpoints for event and PWA manifest management by adding detailed descriptions and response documentation, improves the `ManifestService` with better functionality and documentation, and simplifies UI component schemas by removing unused fields. Below are the most important changes grouped by theme:

### API Enhancements
* Added detailed `description` and `responses` documentation to the `/event` endpoints (`GET`, `POST`, `PUT`) to clarify behavior and possible responses. For example, the `POST /event` endpoint now specifies that it assigns the `cb-organizer` role to the first user and updates the PWA manifest. [[1]](diffhunk://#diff-e1d88cabf3fb4f2855d495db2540cce0d96e850970aea72a5ceeda2558416ddbL16-R36) [[2]](diffhunk://#diff-e1d88cabf3fb4f2855d495db2540cce0d96e850970aea72a5ceeda2558416ddbL26-R72) [[3]](diffhunk://#diff-e1d88cabf3fb4f2855d495db2540cce0d96e850970aea72a5ceeda2558416ddbR103-R135) [[4]](diffhunk://#diff-e1d88cabf3fb4f2855d495db2540cce0d96e850970aea72a5ceeda2558416ddbL103-L110)
* Enhanced the `/manifest.json` endpoints (`GET`, `PUT`, `POST`) with summaries and descriptions to explain their purpose and requirements, such as the `manage_event` role for updates. [[1]](diffhunk://#diff-14c443d6ddeba79600ea25d0942db7613e50dab4535eaa454401dcad8528e2edL11-R13) [[2]](diffhunk://#diff-14c443d6ddeba79600ea25d0942db7613e50dab4535eaa454401dcad8528e2edL21-R26) [[3]](diffhunk://#diff-14c443d6ddeba79600ea25d0942db7613e50dab4535eaa454401dcad8528e2edL33-R41)

### Service Improvements
* Improved `ManifestService` by adding comprehensive docstrings for methods like `get_manifest`, `update_manifest`, and `insert_icon`, explaining their functionality, arguments, and exceptions. [[1]](diffhunk://#diff-fdd204c0a39eb9e2dd5531e0ca7592cba697ab8820a763017d727c3c35784bc2R10-R13) [[2]](diffhunk://#diff-fdd204c0a39eb9e2dd5531e0ca7592cba697ab8820a763017d727c3c35784bc2L21-R55) [[3]](diffhunk://#diff-fdd204c0a39eb9e2dd5531e0ca7592cba697ab8820a763017d727c3c35784bc2L40-R76)
* Changed the `get_manifest` query to use `id` instead of `name` for better consistency and updated the `update_manifest` method to handle creation if no existing manifest is found. [[1]](diffhunk://#diff-fdd204c0a39eb9e2dd5531e0ca7592cba697ab8820a763017d727c3c35784bc2L21-R55) [[2]](diffhunk://#diff-fdd204c0a39eb9e2dd5531e0ca7592cba697ab8820a763017d727c3c35784bc2L40-R76)

### UI Component Schema Simplifications
* Removed the unused `className` field from several UI components (`Button`, `Image`, `Location`, `Text`, `Title`, `Video`) to reduce redundancy and simplify schemas. [[1]](diffhunk://#diff-613a5b9abc0765e9a509826d079fa136f8b2a51f82ca83bb8d5f212a2cc8dfeaL35-L39) [[2]](diffhunk://#diff-020910cfb95133aef58aef8144d7afa2b2cc268896de2b038590167550890c5cL19-L23) [[3]](diffhunk://#diff-ac73328e1ccc91b6f15e8a8d78a7fea32210d833e416f59cdc28e3f105304072L20-L24) [[4]](diffhunk://#diff-a7359619a20ca75703c3a9205893f90db6bd593734befe6cca92bba48d8ba9a1L15-R15) [[5]](diffhunk://#diff-2ecb7abb028bd55c04f6b5425efee7b79377ef6ba5ced13a81038404e697b45eL16-R16) [[6]](diffhunk://#diff-a7af89d5c545e347b59cf68aba6cf82e828def6fb4719d323c82d50cb61d8f03L17-L31)
* Updated the default `color` value in `Text` and `Title` components to `BASE_CONTENT` for consistency. [[1]](diffhunk://#diff-a7359619a20ca75703c3a9205893f90db6bd593734befe6cca92bba48d8ba9a1L15-R15) [[2]](diffhunk://#diff-2ecb7abb028bd55c04f6b5425efee7b79377ef6ba5ced13a81038404e697b45eL16-R16)