### PR TITLE
change default manifest values

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -146,16 +146,15 @@ async def create_default_manifest():
     try:
         _manifest = await manifest_service.get_manifest()
     except ManifestNotFoundError:
-        # Criar manifesto padrão se não existir
         default_manifest = Manifest(
-            id="/app?source=pwa",
+            id="/?source=pwa",
             name="coffeeBreak",
             short_name="coffeeBreak",
             description="An app to manage events",
             display="standalone",
             orientation="portrait",
-            scope="/app",
-            start_url="/app?source=pwa",
+            scope="/",
+            start_url="/?source=pwa",
             background_color="#ffffff",
             theme_color="#ffffff",
             icons=[

--- a/services/manifest.py
+++ b/services/manifest.py
@@ -31,7 +31,9 @@ class ManifestService:
         Raises:
             ManifestNotFoundError: If no manifest exists in the database
         """
-        manifest = await self.manifest_collection.find_one({"id": "/app?source=pwa"})
+        manifest = await self.manifest_collection.find_one(
+            sort=[("_id", -1)]
+        )
         if not manifest:
             raise ManifestNotFoundError()
         return Manifest(**manifest)


### PR DESCRIPTION
This pull request updates the handling of the default manifest and its retrieval logic to streamline the app's configuration and ensure the latest manifest is always used. The changes include adjustments to the default manifest's structure and improvements to the database query for retrieving manifests.

### Updates to default manifest creation:

* In `defaults.py`, the `create_default_manifest` function now sets the `id`, `scope`, and `start_url` fields to root-level paths (`"/"` instead of `"/app"`), aligning with a simplified app structure.

### Improvements to manifest retrieval:

* In `services/manifest.py`, the `get_manifest` function was updated to fetch the most recent manifest from the database by adding a sort operation (`sort=[("_id", -1)]`), ensuring the latest version is always retrieved.