### PR TITLE
Hotfix/manifest default

### DIFF
--- a/defaults.py
+++ b/defaults.py
@@ -146,16 +146,15 @@ async def create_default_manifest():
     try:
         _manifest = await manifest_service.get_manifest()
     except ManifestNotFoundError:
-        # Criar manifesto padrão se não existir
         default_manifest = Manifest(
-            id="/app?source=pwa",
+            id="/?source=pwa",
             name="coffeeBreak",
             short_name="coffeeBreak",
             description="An app to manage events",
             display="standalone",
             orientation="portrait",
-            scope="/app",
-            start_url="/app?source=pwa",
+            scope="/",
+            start_url="/?source=pwa",
             background_color="#ffffff",
             theme_color="#ffffff",
             icons=[

--- a/services/manifest.py
+++ b/services/manifest.py
@@ -31,7 +31,9 @@ class ManifestService:
         Raises:
             ManifestNotFoundError: If no manifest exists in the database
         """
-        manifest = await self.manifest_collection.find_one({"id": "/app?source=pwa"})
+        manifest = await self.manifest_collection.find_one(
+            sort=[("_id", -1)]
+        )
         if not manifest:
             raise ManifestNotFoundError()
         return Manifest(**manifest)


### PR DESCRIPTION
This pull request includes updates to the default manifest creation and retrieval logic to improve flexibility and ensure the most recent manifest is used. The most important changes are as follows:

### Updates to default manifest creation:
* In `defaults.py`, the default manifest's `id`, `scope`, and `start_url` were updated from `"/app?source=pwa"` and `"/app"` to `"/?source=pwa"` and `"/"`, respectively, to simplify URL paths.

### Updates to manifest retrieval logic:
* In `services/manifest.py`, the `get_manifest` method was modified to retrieve the most recent manifest by adding a descending sort on the `_id` field. This ensures the latest manifest is always returned.